### PR TITLE
Add implementation of cckprng API

### DIFF
--- a/corecrypto.xcodeproj/project.pbxproj
+++ b/corecrypto.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1F358E792354F0370030CA4F /* fipspost_trace.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E742354F0370030CA4F /* fipspost_trace.h */; };
 		1F358E7A2354F0370030CA4F /* cc_runtime_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E752354F0370030CA4F /* cc_runtime_config.h */; };
 		1F358E7B2354F0370030CA4F /* cc_error.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E762354F0370030CA4F /* cc_error.h */; };
+		1F358E7D2354F1570030CA4F /* cckprng.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F358E7C2354F1570030CA4F /* cckprng.c */; };
 		1FB2F6C41C87B2EC009C0F4C /* cc_kext_main.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */; };
 		1FB2F6C61C87B42D009C0F4C /* cc_clear.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C51C87B42D009C0F4C /* cc_clear.c */; };
 		1FDA24121D98DA16003D41DA /* cc_functions.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA24061D98D841003D41DA /* cc_functions.c */; };
@@ -56,6 +57,7 @@
 		1F358E742354F0370030CA4F /* fipspost_trace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fipspost_trace.h; sourceTree = "<group>"; };
 		1F358E752354F0370030CA4F /* cc_runtime_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_runtime_config.h; sourceTree = "<group>"; };
 		1F358E762354F0370030CA4F /* cc_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_error.h; sourceTree = "<group>"; };
+		1F358E7C2354F1570030CA4F /* cckprng.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cckprng.c; sourceTree = "<group>"; };
 		1F377BA6213DF17100D1C6CA /* corecrypto.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = corecrypto.xcconfig; sourceTree = "<group>"; };
 		1F4D11C51D9CCA1300782B10 /* md5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
 		1F4D11C81D9CCBA100782B10 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				1F65D0021F2801220073759F /* register_crypto.h */,
 				1FDA24061D98D841003D41DA /* cc_functions.c */,
 				1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */,
+				1F358E7C2354F1570030CA4F /* cckprng.c */,
 				1FB2F6C21C87B2E6009C0F4C /* Info.plist */,
 			);
 			path = kext;
@@ -317,6 +320,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F358E7D2354F1570030CA4F /* cckprng.c in Sources */,
 				1F16A0101C87BFE10071A80A /* cc_cmp_safe.c in Sources */,
 				1F1D445B1F280B5F0043CE92 /* aes_ecb.c in Sources */,
 				1F1D44511F2807CD0043CE92 /* cc_digest.c in Sources */,

--- a/corecrypto.xcodeproj/project.pbxproj
+++ b/corecrypto.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1F358E7B2354F0370030CA4F /* cc_error.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E762354F0370030CA4F /* cc_error.h */; };
 		1F358E7D2354F1570030CA4F /* cckprng.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F358E7C2354F1570030CA4F /* cckprng.c */; };
 		1F6314772354F443008CCB89 /* cckprng.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6314762354F443008CCB89 /* cckprng.h */; };
+		1F6314752354F3DF008CCB89 /* prng_random.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6314742354F3DF008CCB89 /* prng_random.h */; };
 		1FB2F6C41C87B2EC009C0F4C /* cc_kext_main.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */; };
 		1FB2F6C61C87B42D009C0F4C /* cc_clear.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C51C87B42D009C0F4C /* cc_clear.c */; };
 		1FDA24121D98DA16003D41DA /* cc_functions.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA24061D98D841003D41DA /* cc_functions.c */; };
@@ -63,6 +64,7 @@
 		1F4D11C51D9CCA1300782B10 /* md5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
 		1F4D11C81D9CCBA100782B10 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
 		1F6314762354F443008CCB89 /* cckprng.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cckprng.h; sourceTree = "<group>"; };
+		1F6314742354F3DF008CCB89 /* prng_random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prng_random.h; sourceTree = "<group>"; };
 		1F65CFE41F2800C60073759F /* ccmd5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ccmd5.h; sourceTree = "<group>"; };
 		1F65CFE51F2800C60073759F /* ccaes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ccaes.h; sourceTree = "<group>"; };
 		1F65CFE61F2800C60073759F /* ccdrbg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ccdrbg.h; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 			isa = PBXGroup;
 			children = (
 				1F65D0021F2801220073759F /* register_crypto.h */,
+				1F6314742354F3DF008CCB89 /* prng_random.h */,
 				1FDA24061D98D841003D41DA /* cc_functions.c */,
 				1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */,
 				1FB2F6C21C87B2E6009C0F4C /* Info.plist */,
@@ -245,6 +248,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F6314752354F3DF008CCB89 /* prng_random.h in Headers */,
 				1F358E792354F0370030CA4F /* fipspost_trace.h in Headers */,
 				1F358E7B2354F0370030CA4F /* cc_error.h in Headers */,
 				1F332F2C1C8D201C00C74D80 /* cc_abort.h in Headers */,

--- a/corecrypto.xcodeproj/project.pbxproj
+++ b/corecrypto.xcodeproj/project.pbxproj
@@ -22,6 +22,11 @@
 		1F1D445A1F280B5F0043CE92 /* aes_cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F1D44571F280B490043CE92 /* aes_cbc.c */; };
 		1F1D445B1F280B5F0043CE92 /* aes_ecb.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F1D44561F280B490043CE92 /* aes_ecb.c */; };
 		1F332F2C1C8D201C00C74D80 /* cc_abort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F332F2B1C8D201C00C74D80 /* cc_abort.h */; };
+		1F358E772354F0370030CA4F /* cckprng.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E722354F0360030CA4F /* cckprng.h */; };
+		1F358E782354F0370030CA4F /* ccchacha20poly1305.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E732354F0370030CA4F /* ccchacha20poly1305.h */; };
+		1F358E792354F0370030CA4F /* fipspost_trace.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E742354F0370030CA4F /* fipspost_trace.h */; };
+		1F358E7A2354F0370030CA4F /* cc_runtime_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E752354F0370030CA4F /* cc_runtime_config.h */; };
+		1F358E7B2354F0370030CA4F /* cc_error.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E762354F0370030CA4F /* cc_error.h */; };
 		1FB2F6C41C87B2EC009C0F4C /* cc_kext_main.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */; };
 		1FB2F6C61C87B42D009C0F4C /* cc_clear.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C51C87B42D009C0F4C /* cc_clear.c */; };
 		1FDA24121D98DA16003D41DA /* cc_functions.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA24061D98D841003D41DA /* cc_functions.c */; };
@@ -46,6 +51,11 @@
 		1F1D44571F280B490043CE92 /* aes_cbc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aes_cbc.c; sourceTree = "<group>"; };
 		1F1D44581F280B490043CE92 /* aes128.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aes128.c; sourceTree = "<group>"; };
 		1F332F2B1C8D201C00C74D80 /* cc_abort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_abort.h; sourceTree = "<group>"; };
+		1F358E722354F0360030CA4F /* cckprng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cckprng.h; sourceTree = "<group>"; };
+		1F358E732354F0370030CA4F /* ccchacha20poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccchacha20poly1305.h; sourceTree = "<group>"; };
+		1F358E742354F0370030CA4F /* fipspost_trace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fipspost_trace.h; sourceTree = "<group>"; };
+		1F358E752354F0370030CA4F /* cc_runtime_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_runtime_config.h; sourceTree = "<group>"; };
+		1F358E762354F0370030CA4F /* cc_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_error.h; sourceTree = "<group>"; };
 		1F377BA6213DF17100D1C6CA /* corecrypto.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = corecrypto.xcconfig; sourceTree = "<group>"; };
 		1F4D11C51D9CCA1300782B10 /* md5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
 		1F4D11C81D9CCBA100782B10 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
@@ -161,10 +171,13 @@
 				1F65CFE91F2800C60073759F /* cc.h */,
 				1F65CFF71F2800C60073759F /* cc_config.h */,
 				1F65CFE71F2800C60073759F /* cc_debug.h */,
+				1F358E762354F0370030CA4F /* cc_error.h */,
 				1F65CFF01F2800C60073759F /* cc_macros.h */,
 				1F65CFFE1F2800C60073759F /* cc_priv.h */,
+				1F358E752354F0370030CA4F /* cc_runtime_config.h */,
 				1F65CFE51F2800C60073759F /* ccaes.h */,
 				1F65D0011F2800C60073759F /* ccasn1.h */,
+				1F358E732354F0370030CA4F /* ccchacha20poly1305.h */,
 				1F65CFFF1F2800C60073759F /* cccmac.h */,
 				1F65CFEB1F2800C60073759F /* ccder.h */,
 				1F65CFEC1F2800C60073759F /* ccdes.h */,
@@ -173,6 +186,7 @@
 				1F65CFE81F2800C60073759F /* ccdrbg_impl.h */,
 				1F65CFE61F2800C60073759F /* ccdrbg.h */,
 				1F65CFED1F2800C60073759F /* cchmac.h */,
+				1F358E722354F0360030CA4F /* cckprng.h */,
 				1F65CFE41F2800C60073759F /* ccmd5.h */,
 				1F65D0001F2800C60073759F /* ccmode_factory.h */,
 				1F65CFF61F2800C60073759F /* ccmode_impl.h */,
@@ -188,6 +202,7 @@
 				1F65CFF91F2800C60073759F /* ccsha1.h */,
 				1F65CFF11F2800C60073759F /* ccsha2.h */,
 				1F65CFEF1F2800C60073759F /* cczp.h */,
+				1F358E742354F0370030CA4F /* fipspost_trace.h */,
 			);
 			path = corecrypto;
 			sourceTree = "<group>";
@@ -224,7 +239,12 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F358E792354F0370030CA4F /* fipspost_trace.h in Headers */,
+				1F358E7B2354F0370030CA4F /* cc_error.h in Headers */,
 				1F332F2C1C8D201C00C74D80 /* cc_abort.h in Headers */,
+				1F358E772354F0370030CA4F /* cckprng.h in Headers */,
+				1F358E782354F0370030CA4F /* ccchacha20poly1305.h in Headers */,
+				1F358E7A2354F0370030CA4F /* cc_runtime_config.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/corecrypto.xcodeproj/project.pbxproj
+++ b/corecrypto.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1F358E7A2354F0370030CA4F /* cc_runtime_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E752354F0370030CA4F /* cc_runtime_config.h */; };
 		1F358E7B2354F0370030CA4F /* cc_error.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F358E762354F0370030CA4F /* cc_error.h */; };
 		1F358E7D2354F1570030CA4F /* cckprng.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F358E7C2354F1570030CA4F /* cckprng.c */; };
+		1F6314772354F443008CCB89 /* cckprng.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6314762354F443008CCB89 /* cckprng.h */; };
 		1FB2F6C41C87B2EC009C0F4C /* cc_kext_main.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */; };
 		1FB2F6C61C87B42D009C0F4C /* cc_clear.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FB2F6C51C87B42D009C0F4C /* cc_clear.c */; };
 		1FDA24121D98DA16003D41DA /* cc_functions.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA24061D98D841003D41DA /* cc_functions.c */; };
@@ -61,6 +62,7 @@
 		1F377BA6213DF17100D1C6CA /* corecrypto.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = corecrypto.xcconfig; sourceTree = "<group>"; };
 		1F4D11C51D9CCA1300782B10 /* md5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
 		1F4D11C81D9CCBA100782B10 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
+		1F6314762354F443008CCB89 /* cckprng.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cckprng.h; sourceTree = "<group>"; };
 		1F65CFE41F2800C60073759F /* ccmd5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ccmd5.h; sourceTree = "<group>"; };
 		1F65CFE51F2800C60073759F /* ccaes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ccaes.h; sourceTree = "<group>"; };
 		1F65CFE61F2800C60073759F /* ccdrbg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ccdrbg.h; sourceTree = "<group>"; };
@@ -139,6 +141,8 @@
 		1F4D11C41D9CC9FF00782B10 /* algorithms */ = {
 			isa = PBXGroup;
 			children = (
+				1F6314762354F443008CCB89 /* cckprng.h */,
+				1F358E7C2354F1570030CA4F /* cckprng.c */,
 				1F1D44431F2802BD0043CE92 /* pdcrypto_digest_final.h */,
 				1F1D443E1F2802BD0043CE92 /* pdcrypto_digest_final.c */,
 				1F1D443F1F2802BD0043CE92 /* pdcrypto_digest_init.h */,
@@ -229,7 +233,6 @@
 				1F65D0021F2801220073759F /* register_crypto.h */,
 				1FDA24061D98D841003D41DA /* cc_functions.c */,
 				1FB2F6C11C87B2E6009C0F4C /* cc_kext_main.c */,
-				1F358E7C2354F1570030CA4F /* cckprng.c */,
 				1FB2F6C21C87B2E6009C0F4C /* Info.plist */,
 			);
 			path = kext;
@@ -248,6 +251,7 @@
 				1F358E772354F0370030CA4F /* cckprng.h in Headers */,
 				1F358E782354F0370030CA4F /* ccchacha20poly1305.h in Headers */,
 				1F358E7A2354F0370030CA4F /* cc_runtime_config.h in Headers */,
+				1F6314772354F443008CCB89 /* cckprng.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/include/corecrypto/cc_config.h
+++ b/include/corecrypto/cc_config.h
@@ -12,9 +12,9 @@
 #define _CORECRYPTO_CC_CONFIG_H_
 
 /* A word about configuration macros:
- 
+
     Conditional configuration macros specific to corecrypto should be named CORECRYPTO_xxx
-    or CCxx_yyy and be defined to be either 0 or 1 in this file. You can add an 
+    or CCxx_yyy and be defined to be either 0 or 1 in this file. You can add an
     #ifndef #error construct at the end of this file to make sure it's always defined.
 
     They should always be tested using the #if directive, never the #ifdef directive.
@@ -23,40 +23,34 @@
 
     Configuration Macros that are defined outside of corecrypto (eg: KERNEL, DEBUG, ...)
     shall only be used in this file to define CCxxx macros.
- 
+
     External macros should be assumed to be either undefined, defined with no value,
     or defined as true or false. We shall strive to build with -Wundef whenever possible,
     so the following construct should be used to test external macros in this file:
-  
+
          #if defined(DEBUG) && (DEBUG)
          #define CORECRYPTO_DEBUG 1
          #else
          #define CORECRYPTO_DEBUG 0
          #endif
-  
+
 
     It is acceptable to define a conditional CC_xxxx macro in an implementation file,
     to be used only in this file.
- 
+
     The current code is not guaranteed to follow those rules, but should be fixed to.
- 
+
     Corecrypto requires GNU and C99 compatibility.
     Typically enabled by passing --gnu --c99 to the compiler (eg. armcc)
 
 */
 
-//Do not set these macros to 1, unless you are developing/testing for Windows
-#define CORECRYPTO_SIMULATE_WINDOWS_ENVIRONMENT 0
-#define CORECRYPTO_HACK_FOR_WINDOWS_DEVELOPMENT 0 //to be removed after <rdar://problem/26585938> port corecrypto to Windows
+//Do not set this macros to 1, unless you are developing/testing for Linux under macOS
+#define CORECRYPTO_SIMULATE_POSIX_ENVIRONMENT    0
 
-//this macro is used to turn on/off usage of transparent union in corecrypto
-//it should be commented out in corecrypto and be used only by the software that use corecrypto
-//#define CORECRYPTO_DONOT_USE_TRANSPARENT_UNION
-#ifdef CORECRYPTO_DONOT_USE_TRANSPARENT_UNION
- #define CORECRYPTO_USE_TRANSPARENT_UNION 0
-#else
- #define CORECRYPTO_USE_TRANSPARENT_UNION 1
-#endif
+//Do not set these macros to 1, unless you are developing/testing for Windows under macOS
+#define CORECRYPTO_SIMULATE_WINDOWS_ENVIRONMENT 0
+#define CORECRYPTO_HACK_FOR_WINDOWS_DEVELOPMENT 0 //to be removed after <rdar://problem/27304763> port corecrypto to Windows
 
 #if (defined(DEBUG) && (DEBUG)) || defined(_DEBUG) //MSVC defines _DEBUG
 /* CC_DEBUG is already used in CommonCrypto */
@@ -76,9 +70,7 @@
  #define CC_KERNEL 0
 #endif
 
-// LINUX_BUILD_TEST is for sanity check of the configuration
-// > xcodebuild -scheme "corecrypto_test" OTHER_CFLAGS="$(values) -DLINUX_BUILD_TEST"
-#if defined(__linux__) || defined(LINUX_BUILD_TEST)
+#if defined(__linux__) || CORECRYPTO_SIMULATE_POSIX_ENVIRONMENT
  #define CC_LINUX 1
 #else
  #define CC_LINUX 0
@@ -88,6 +80,18 @@
  #define CC_USE_L4 1
 #else
  #define CC_USE_L4 0
+#endif
+
+#if defined(RTKIT) && (RTKIT)
+ #define CC_RTKIT 1
+#else
+ #define CC_RTKIT 0
+#endif
+
+#if defined(RTKITROM) && (RTKITROM)
+#define CC_RTKITROM 1
+#else
+#define CC_RTKITROM 0
 #endif
 
 #if defined(USE_SEPROM) && (USE_SEPROM)
@@ -120,20 +124,32 @@
  #define CC_IBOOT 0
 #endif
 
-// BB configuration
+// Defined by the XNU build scripts
+// Applies to code embedded in XNU but NOT to the kext
+#if defined(XNU_KERNEL_PRIVATE)
+ #define CC_XNU_KERNEL_PRIVATE 1
+#else
+ #define CC_XNU_KERNEL_PRIVATE 0
+#endif
+
+// handle unaligned data, if the cpu cannot. Currently for gladman AES and the C version of the SHA256
+#define CC_HANDLE_UNALIGNED_DATA CC_BASEBAND
+
+// BaseBand configuration
 #if CC_BASEBAND
 
 // -- ENDIANESS
+#if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
  #if defined(ENDIAN_LITTLE) || (defined(__arm__) && !defined(__BIG_ENDIAN))
   #define __LITTLE_ENDIAN__
  #elif !defined(ENDIAN_BIG) && !defined(__BIG_ENDIAN)
   #error Baseband endianess not defined.
  #endif
  #define AESOPT_ENDIAN_NO_FILE
+#endif
 
 // -- Architecture
  #define CCN_UNIT_SIZE  4 // 32 bits
- #define SAFE_IO          // AES support for unaligned Input/Output
 
 // -- External function
  #define assert ASSERT   // sanity
@@ -143,12 +159,24 @@
 // #1254-D: arithmetic on pointer to void or function type
 // #186-D: pointless comparison of unsigned integer with zero
 // #546-D: transfer of control bypasses initialization of
- #if   defined(__GNUC__)
+ #ifdef __arm__
+  #pragma diag_suppress 186, 1254,546
+ #elif defined(__GNUC__)
 // warning: pointer of type 'void *' used in arithmetic
   #pragma GCC diagnostic ignored "-Wpointer-arith"
- #endif // arm or gnuc
+ #endif // __arm__
+#define CC_SMALL_CODE 1
 
 #endif // CC_BASEBAND
+
+#if CC_RTKIT || CC_RTKITROM
+#define CC_SMALL_CODE 1
+#endif
+
+
+#ifndef CC_SMALL_CODE
+#define CC_SMALL_CODE 0
+#endif
 
 //CC_XNU_KERNEL_AVAILABLE indicates the availibity of XNU kernel functions,
 //like what we have on OSX, iOS, tvOS, Watch OS
@@ -158,8 +186,13 @@
  #define CC_XNU_KERNEL_AVAILABLE 0
 #endif
 
+//arm arch64 definition for gcc
+#if defined(__GNUC__) && defined(__aarch64__) && !defined(__arm64__)
+    #define __arm64__
+#endif
+
 #if !defined(CCN_UNIT_SIZE)
- #if defined(__arm64__) || defined(__x86_64__)  || defined(_WIN64) 
+ #if defined(__arm64__) || defined(__x86_64__)  || defined(_WIN64)
   #define CCN_UNIT_SIZE  8
  #elif defined(__arm__) || defined(__i386__) || defined(_WIN32)
   #define CCN_UNIT_SIZE  4
@@ -192,19 +225,38 @@
  #endif
 #endif
 
-#if __clang__ || CCN_UNIT_SIZE==8
- #define CC_ALIGNED(x) __attribute__ ((aligned(x)))
-#elif _MSC_VER
- #define CC_ALIGNED(x) __declspec(align(x))
+#if defined(_MSC_VER)
+    #if defined(__clang__)
+        #define CC_ALIGNED(x) __attribute__ ((aligned(x))) //clang compiler
+    #else
+        #define CC_ALIGNED(x) __declspec(align(x)) //MS complier
+    #endif
 #else
- #define CC_ALIGNED(x) __attribute__ ((aligned((x)>8?8:(x))))
+    #if __clang__ || CCN_UNIT_SIZE==8
+        #define CC_ALIGNED(x) __attribute__ ((aligned(x)))
+    #else
+        #define CC_ALIGNED(x) __attribute__ ((aligned((x)>8?8:(x))))
+    #endif
 #endif
 
+#if defined(__arm__)
+//this is copied from <arm/arch.h>, because <arm/arch.h> is not available on SEPROM environment
+#if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7S__) || defined (__ARM_ARCH_7F__) || defined (__ARM_ARCH_7K__) || defined(__ARM_ARCH_7EM__)
+  #define _ARM_ARCH_7
+ #endif
 
-#if   defined(__x86_64__) || defined(__i386__)
+ #if defined(__ARM_ARCH_6M__) || defined(__TARGET_ARCH_6S_M) || defined (__armv6m__)
+  #define _ARM_ARCH_6M
+ #endif
+#endif
+
+#if defined(__arm64__) || defined(__arm__)
+ #define CCN_IOS				   1
+ #define CCN_OSX				   0
+#elif defined(__x86_64__) || defined(__i386__)
  #define CCN_IOS				   0
  #define CCN_OSX				   1
-#endif 
+#endif
 
 #if CC_USE_L4 || CC_USE_S3
 /* No dynamic linking allowed in L4, e.g. avoid nonlazy symbols */
@@ -213,17 +265,15 @@
 #endif
 
 #if !defined(CC_USE_HEAP_FOR_WORKSPACE)
- #if CC_USE_L4 || CC_IBOOT || defined(_MSC_VER)
- /* For L4, stack is too short, need to use HEAP for some computations */
- /* CC_USE_HEAP_FOR_WORKSPACE not supported for KERNEL!  */
-  #define CC_USE_HEAP_FOR_WORKSPACE 1
- #else
+ #if CC_USE_S3 || CC_USE_SEPROM || CC_RTKITROM
   #define CC_USE_HEAP_FOR_WORKSPACE 0
+ #else
+  #define CC_USE_HEAP_FOR_WORKSPACE 1
  #endif
 #endif
 
 /* memset_s is only available in few target */
-#if CC_KERNEL || CC_USE_SEPROM || defined(__CC_ARM) \
+#if CC_USE_SEPROM || defined(__CC_ARM) \
     || defined(__hexagon__) || CC_EFI
  #define CC_HAS_MEMSET_S 0
 #else
@@ -237,23 +287,30 @@
 #endif /* __has_include(<TargetConditionals.h>) */
 #endif /* defined(__has_include) */
 
-// Disable FIPS key gen algorithm on userland and kext so that related POST
-// is skipped and boot time is reduced
+// Disable RSA Keygen on iBridge
 #if defined(TARGET_OS_BRIDGE) && TARGET_OS_BRIDGE && CC_KERNEL
 #define CC_DISABLE_RSAKEYGEN 1 /* for iBridge */
 #else
 #define CC_DISABLE_RSAKEYGEN 0 /* default */
 #endif
 
+// see rdar://problem/26636018
+#if (CCN_UNIT_SIZE == 8) && !( defined(_MSC_VER) && defined(__clang__))
+#define CCEC25519_CURVE25519DONNA_64BIT 1
+#else
+#define CCEC25519_CURVE25519DONNA_64BIT 0
+#endif
+
 //- functions implemented in assembly ------------------------------------------
 //this the list of corecrypto clients that use assembly and the clang compiler
-#if !(CC_XNU_KERNEL_AVAILABLE || CC_KERNEL || CC_USE_L4 || CC_IBOOT || CC_USE_SEPROM || CC_USE_S3) && !defined(_WIN32) && CORECRYPTO_DEBUG
+#if !(CC_XNU_KERNEL_AVAILABLE || CC_KERNEL || CC_USE_L4 || CC_IBOOT || CC_RTKIT || CC_RTKITROM || CC_USE_SEPROM || CC_USE_S3) && !defined(_WIN32) && CORECRYPTO_DEBUG
  #warning "You are using the default corecrypto configuration, assembly optimizations may not be available for your platform"
 #endif
 
-// use this macro to strictly disable assembly regardless of cpu/os/compiler/etc
+// Use this macro to strictly disable assembly regardless of cpu/os/compiler/etc.
+// Our assembly code is not gcc compatible. Clang defines the __GNUC__ macro as well.
 #if !defined(CC_USE_ASM)
- #if defined(_MSC_VER) || CC_LINUX || CC_EFI || CC_BASEBAND
+ #if defined(_WIN32) || CC_EFI || CC_BASEBAND || CC_XNU_KERNEL_PRIVATE || (defined(__GNUC__) && !defined(__clang__)) || defined(__ANDROID_API__) || CC_RTKIT || CC_RTKITROM
   #define CC_USE_ASM 0
  #else
   #define CC_USE_ASM 1
@@ -262,7 +319,7 @@
 
 //-(1) ARM V7
 #if defined(_ARM_ARCH_7) && __clang__ && CC_USE_ASM
- #define CCN_DEDICATED_SQR      1
+ #define CCN_DEDICATED_SQR      CC_SMALL_CODE
  #define CCN_MUL_KARATSUBA      0 // no performance improvement
  #define CCN_ADD_ASM            1
  #define CCN_SUB_ASM            1
@@ -277,7 +334,7 @@
  #define CCN_SHIFT_RIGHT_ASM    1
  #define CCAES_ARM_ASM          1
  #define CCAES_INTEL_ASM        0
- #if CC_KERNEL || CC_USE_L4 || CC_IBOOT || CC_USE_SEPROM || CC_USE_S3
+ #if CC_KERNEL || CC_USE_L4 || CC_IBOOT || CC_RTKIT || CC_RTKITROM || CC_USE_SEPROM || CC_USE_S3
   #define CCAES_MUX             0
  #else
   #define CCAES_MUX             1
@@ -296,6 +353,31 @@
  #define CCSHA256_ARMV6M_ASM 0
 
 //-(2) ARM 64
+#elif defined(__arm64__) && __clang__ && CC_USE_ASM
+ #define CCN_DEDICATED_SQR      CC_SMALL_CODE
+ #define CCN_MUL_KARATSUBA      1 // 4*n CCN_UNIT extra memory required.
+ #define CCN_ADD_ASM            1
+ #define CCN_SUB_ASM            1
+ #define CCN_MUL_ASM            1
+ #define CCN_ADDMUL1_ASM        0
+ #define CCN_MUL1_ASM           0
+ #define CCN_CMP_ASM            1
+ #define CCN_ADD1_ASM           0
+ #define CCN_SUB1_ASM           0
+ #define CCN_N_ASM              1
+ #define CCN_SET_ASM            0
+ #define CCN_SHIFT_RIGHT_ASM    1
+ #define CCAES_ARM_ASM          1
+ #define CCAES_INTEL_ASM        0
+ #define CCAES_MUX              0        // On 64bit SoC, asm is much faster than HW
+ #define CCN_USE_BUILTIN_CLZ    1
+ #define CCSHA1_VNG_INTEL       0
+ #define CCSHA2_VNG_INTEL       0
+ #define CCSHA1_VNG_ARMV7NEON   1		// reused this to avoid making change to xcode project, put arm64 assembly code with armv7 code
+ #define CCSHA2_VNG_ARMV7NEON   1
+ #define CCSHA256_ARMV6M_ASM    0
+
+//-(3) Intel 32/64
 #elif (defined(__x86_64__) || defined(__i386__)) && __clang__ && CC_USE_ASM
  #define CCN_DEDICATED_SQR      1
  #define CCN_MUL_KARATSUBA      1 // 4*n CCN_UNIT extra memory required.
@@ -335,7 +417,7 @@
  #define CCSHA2_VNG_ARMV7NEON   0
  #define CCSHA256_ARMV6M_ASM    0
 
-//-(4) disable assembly  
+//-(4) disable assembly
 #else
  #if CCN_UINT128_SUPPORT_FOR_64BIT_ARCH
   #define CCN_DEDICATED_SQR     1
@@ -368,25 +450,11 @@
 
 #define CC_INLINE static inline
 
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-// Non null for transparent unions is ambiguous and cause problems
-// for most tools (GCC and others: 23919290).
- #define CC_NONNULL_TU(N)
-#else
- #define CC_NONNULL_TU(N)  CC_NONNULL(N)
-#endif
-
 #ifdef __GNUC__
  #define CC_NORETURN __attribute__((__noreturn__))
  #define CC_NOTHROW __attribute__((__nothrow__))
  #define CC_NONNULL(N) __attribute__((__nonnull__ N))
- #define CC_NONNULL1 __attribute__((__nonnull__(1)))
- #define CC_NONNULL2 __attribute__((__nonnull__(2)))
- #define CC_NONNULL3 __attribute__((__nonnull__(3)))
- #define CC_NONNULL4 __attribute__((__nonnull__(4)))
- #define CC_NONNULL5 __attribute__((__nonnull__(5)))
- #define CC_NONNULL6 __attribute__((__nonnull__(6)))
- #define CC_NONNULL7 __attribute__((__nonnull__(7)))
+ #define CC_NONNULL4 CC_NONNULL((4))
  #define CC_NONNULL_ALL __attribute__((__nonnull__))
  #define CC_SENTINEL __attribute__((__sentinel__))
  #define CC_CONST __attribute__((__const__))
@@ -400,23 +468,11 @@
 /*! @parseOnly */
  #define CC_NONNULL(N)
 /*! @parseOnly */
+ #define CC_NONNULL4
+/*! @parseOnly */
  #define CC_NORETURN
 /*! @parseOnly */
  #define CC_NOTHROW
-/*! @parseOnly */
- #define CC_NONNULL1
-/*! @parseOnly */
- #define CC_NONNULL2
-/*! @parseOnly */
- #define CC_NONNULL3
-/*! @parseOnly */
- #define CC_NONNULL4
-/*! @parseOnly */
- #define CC_NONNULL5
-/*! @parseOnly */
- #define CC_NONNULL6
-/*! @parseOnly */
- #define CC_NONNULL7
 /*! @parseOnly */
  #define CC_NONNULL_ALL
 /*! @parseOnly */
@@ -431,5 +487,11 @@
  #define CC_MALLOC
 #endif /* !__GNUC__ */
 
+// Enable FIPSPOST function tracing only when supported. */
+#ifdef CORECRYPTO_POST_TRACE
+#define CC_FIPSPOST_TRACE 1
+#else
+#define CC_FIPSPOST_TRACE 0
+#endif
 
 #endif /* _CORECRYPTO_CC_CONFIG_H_ */

--- a/include/corecrypto/cc_debug.h
+++ b/include/corecrypto/cc_debug.h
@@ -21,15 +21,20 @@
 // Printf for corecrypto
 // ========================
 #if CC_KERNEL
-#include <pexpert/pexpert.h>
-#define cc_printf(x...) kprintf(x)
-extern int printf(const char *format, ...) __printflike(1,2);
-#elif CC_USE_S3
-#include <stdio.h>
-#define cc_printf(x...) printf(x)
+    #include <pexpert/pexpert.h>
+    #define cc_printf(x...) kprintf(x)
+    #if !CONFIG_EMBEDDED
+        extern int printf(const char *format, ...) __printflike(1,2);
+    #endif
+#elif CC_USE_S3 || CC_IBOOT || CC_RTKIT || CC_RTKITROM
+    #include <stdio.h>
+    #define cc_printf(x...) printf(x)
+#elif defined(__ANDROID_API__)
+    #include <android/log.h>
+    #define cc_printf(x...) __android_log_print(ANDROID_LOG_DEBUG, "corecrypto", x);
 #else
-#include <stdio.h>
-#define cc_printf(x...) fprintf(stderr, x)
+    #include <stdio.h>
+    #define cc_printf(x...) fprintf(stderr, x)
 #endif
 
 // ========================

--- a/include/corecrypto/cc_error.h
+++ b/include/corecrypto/cc_error.h
@@ -1,0 +1,124 @@
+/*
+ *  cc_error.h
+ *  corecrypto
+ *
+ *  Created on 11/14/2017
+ *
+ *  Copyright (c) 2017 Apple Inc. All rights reserved.
+ *
+ */
+
+#ifndef _CORECRYPTO_CC_ERROR_H_
+#define _CORECRYPTO_CC_ERROR_H_
+
+enum {
+    CCERR_OK = 0,
+
+    /* the default error code */
+    CCERR_INTERNAL = -1,
+
+    CCERR_INTEGRITY = -2,
+
+    CCERR_DEVICE = -3,
+    CCERR_INTERRUPTS = -4,
+    CCERR_CRYPTO_CONFIG = -5,
+    CCERR_PERMS = -6,
+    CCERR_PARAMETER = -7,
+    CCERR_MEMORY = -8,
+    CCERR_FILEDESC = -9,
+    CCERR_OUT_OF_ENTROPY = -10,
+    CCERR_ATFORK = -11,
+    CCERR_OVERFLOW = -12,
+
+    CCERR_MEMORY_ALLOC_FAIL = -13,
+
+    CCEC_GENERATE_KEY_DEFAULT_ERR = -14,
+    CCEC_GENERATE_KEY_TOO_MANY_TRIES = -15,
+    CCEC_GENERATE_KEY_MULT_FAIL = -16,
+    CCEC_GENERATE_KEY_AFF_FAIL = -17,
+    CCEC_GENERATE_KEY_CONSISTENCY = -18,
+    CCEC_GENERATE_NOT_ON_CURVE = -19,
+    CCEC_GENERATE_NOT_ENOUGH_ENTROPY = -20,
+    CCEC_GENERATE_NOT_SUPPORTED = -21,
+    CCEC_GENERATE_INVALID_INPUT = -22,
+
+    // Program error: buffer too small or encrypted message is too small
+    CCRSA_INVALID_INPUT = -23,
+    // Invalid crypto configuration: Hash length versus RSA key size
+    CCRSA_INVALID_CONFIG = -24,
+    CCRSA_ENCODING_ERROR = -25,
+    CCRSA_DECODING_ERROR = -26,
+
+    // The data is invalid (we won't say more for security)
+    CCRSA_PRIVATE_OP_ERROR = -27,
+    CCRSA_KEY_ERROR = -28,
+
+    // Key generation specific
+    CCRSA_KEYGEN_PRIME_NOT_FOUND = -29,
+    CCRSA_KEYGEN_PRIME_NEED_NEW_SEED = -30,
+    CCRSA_KEYGEN_PRIME_TOO_MANY_ITERATIONS = -31,
+    CCRSA_KEYGEN_PRIME_SEED_GENERATION_ERROR = -32,
+    CCRSA_KEYGEN_MODULUS_CRT_INV_ERROR = -33,
+    CCRSA_KEYGEN_NEXT_PRIME_ERROR = -34,
+    CCRSA_KEYGEN_SEED_X_ERROR = -35,
+    CCRSA_KEYGEN_SEED_r_ERROR = -36,
+    CCRSA_KEYGEN_KEYGEN_CONSISTENCY_FAIL = -37,
+    CCRSA_KEYGEN_R1R2_SIZE_ERROR = -38,
+    CCRSA_KEYGEN_PQ_DELTA_ERROR = -39,
+
+    CCRSA_FIPS_KEYGEN_DISABLED = -40,
+
+    CCZP_INV_ERROR = -41,
+    CCZP_INV_NO_INVERSE = -42,
+    CCZP_INV_INVALID_INPUT = -43,
+
+    CCZ_INVALID_INPUT_ERROR = -44,
+    CCZ_INVALID_RADIX_ERROR = -45,
+
+    CCDH_ERROR_DEFAULT = -46,
+    CCDH_GENERATE_KEY_TOO_MANY_TRIES = -47,
+    CCDH_NOT_SUPPORTED_CONFIGURATION = -48,
+    CCDH_SAFETY_CHECK = -49,
+    CCDH_PUBLIC_KEY_MISSING = -50,
+    CCDH_INVALID_DOMAIN_PARAMETER = -51,
+    CCDH_INVALID_INPUT = -52,
+    CCDH_DOMAIN_PARAMETER_MISMATCH = -53,
+    CCDH_GENERATE_KEY_CONSISTENCY = -54,
+
+    CCSRP_ERROR_DEFAULT = -55,
+    CCSRP_GENERATE_KEY_TOO_MANY_TRIES = -56,
+    CCSRP_NOT_SUPPORTED_CONFIGURATION = -57,
+    CCSRP_SAFETY_CHECK = -58,
+    CCSRP_PUBLIC_KEY_MISSING = -59,
+    CCSRP_INVALID_DOMAIN_PARAMETER = -60,
+
+    CCDRBG_STATUS_ERROR = -61,
+    CCDRBG_STATUS_NEED_RESEED = -62,
+    CCDRBG_STATUS_PARAM_ERROR = -63,
+    // If this value is returned, the caller must abort or panic the process for
+    // security reasons. for example in the case of catastrophic error in
+    // http://csrc.nist.gov/publications/drafts/800-90/sp800_90a_r1_draft.pdf
+    // ccdrbg calls abort() or panic(), if they are available in the system.
+    CCDRBG_STATUS_ABORT = -64,
+
+    CCKPRNG_NEED_ENTROPY = -65,
+    CCKPRNG_ABORT = -66,
+
+    CCMODE_INVALID_INPUT = -67,
+    CCMODE_INVALID_CALL_SEQUENCE = -68,
+    CCMODE_INTEGRITY_FAILURE = -69,
+    CCMODE_NOT_SUPPORTED = -70,
+    CCMODE_INTERNAL_ERROR = -71,
+
+    // Configuration or unexpected issue
+    CCPOST_GENERIC_FAILURE = -72,
+    CCPOST_LIBRARY_ERROR = -73,
+    CCPOST_INTEGRITY_ERROR = -74,
+    // Output of the algo is not as expected
+    CCPOST_KAT_FAILURE = -75,
+};
+
+#define CCDRBG_STATUS_OK CCERR_OK
+#define CCKPRNG_OK CCERR_OK
+
+#endif /* _CORECRYPTO_CC_ERROR_H_ */

--- a/include/corecrypto/cc_priv.h
+++ b/include/corecrypto/cc_priv.h
@@ -53,14 +53,9 @@ The following are not defined yet... define them if needed.
  CC_BSWAP64c : byte swap a 64 bits constant
 
  CC_READ_LE32 : read a 32 bits little endian value
- CC_READ_LE64 : read a 64 bits little endian value
- CC_READ_BE32 : read a 32 bits big endian value
- CC_READ_BE64 : read a 64 bits big endian value
 
  CC_WRITE_LE32 : write a 32 bits little endian value
  CC_WRITE_LE64 : write a 64 bits little endian value
- CC_WRITE_BE32 : write a 32 bits big endian value
- CC_WRITE_BE64 : write a 64 bits big endian value
 
  CC_H2BE64 : convert a 64 bits value between host and big endian order
  CC_H2LE64 : convert a 64 bits value between host and little endian order
@@ -360,6 +355,32 @@ CC_INLINE uint32_t CC_BSWAP(uint32_t x)
 #define CC_H2LE32(x) CC_BSWAP(x)
 #endif
 
+#define	CC_READ_LE32(ptr) \
+( (uint32_t)( \
+((uint32_t)((const uint8_t *)(ptr))[0]) | \
+(((uint32_t)((const uint8_t *)(ptr))[1]) <<  8) | \
+(((uint32_t)((const uint8_t *)(ptr))[2]) << 16) | \
+(((uint32_t)((const uint8_t *)(ptr))[3]) << 24)))
+
+#define	CC_WRITE_LE32(ptr, x) \
+do { \
+((uint8_t *)(ptr))[0] = (uint8_t)( (x)        & 0xFF); \
+((uint8_t *)(ptr))[1] = (uint8_t)(((x) >>  8) & 0xFF); \
+((uint8_t *)(ptr))[2] = (uint8_t)(((x) >> 16) & 0xFF); \
+((uint8_t *)(ptr))[3] = (uint8_t)(((x) >> 24) & 0xFF); \
+} while(0)
+
+#define	CC_WRITE_LE64(ptr, x) \
+do { \
+((uint8_t *)(ptr))[0] = (uint8_t)( (x)        & 0xFF); \
+((uint8_t *)(ptr))[1] = (uint8_t)(((x) >>  8) & 0xFF); \
+((uint8_t *)(ptr))[2] = (uint8_t)(((x) >> 16) & 0xFF); \
+((uint8_t *)(ptr))[3] = (uint8_t)(((x) >> 24) & 0xFF); \
+((uint8_t *)(ptr))[4] = (uint8_t)(((x) >> 32) & 0xFF); \
+((uint8_t *)(ptr))[5] = (uint8_t)(((x) >> 40) & 0xFF); \
+((uint8_t *)(ptr))[6] = (uint8_t)(((x) >> 48) & 0xFF); \
+((uint8_t *)(ptr))[7] = (uint8_t)(((x) >> 56) & 0xFF); \
+} while(0)
 
 /* extract a byte portably */
 #ifdef _MSC_VER
@@ -413,8 +434,8 @@ CC_INLINE uint32_t CC_BSWAP(uint32_t x)
 #define cc_ceiling(a,b)  (((a)+((b)-1))/(b))
 #define CC_BITLEN_TO_BYTELEN(x) cc_ceiling((x), 8)
 
-//cc_abort() is implemented to comply with FIPS 140-2. See radar 19129408
-void cc_abort(const char * msg , ...);
+//cc_try_abort() is implemented to comply with FIPS 140-2. See radar 19129408
+void cc_try_abort(const char * msg , ...);
 
 /*!
  @brief     cc_muxp(s, a, b) is equivalent to z = s ? a : b, but it executes in constant time
@@ -450,6 +471,12 @@ void cc_mux2p(int s, void **r_true, void **r_false, const void *a, const void *b
     r = (~_cond&(a))|(_cond&(b)); \
 }
 
-int cc_is_compiled_with_tu(void);
+/*
+  Unfortunately, since we export this symbol, this declaration needs
+  to be in a public header to satisfy TAPI.
+
+  See fipspost_trace_priv.h for more details.
+*/
+extern const void *fipspost_trace_vtable;
 
 #endif /* _CORECRYPTO_CC_PRIV_H_ */

--- a/include/corecrypto/cc_runtime_config.h
+++ b/include/corecrypto/cc_runtime_config.h
@@ -1,0 +1,51 @@
+/*
+ *  cc_runtime_config.h
+ *  corecrypto
+ *
+ *  Created on 09/18/2012
+ *
+ *  Copyright (c) 2012,2014,2015 Apple Inc. All rights reserved.
+ *
+ */
+
+#ifndef CORECRYPTO_CC_RUNTIME_CONFIG_H_
+#define CORECRYPTO_CC_RUNTIME_CONFIG_H_
+
+#include <corecrypto/cc_config.h>
+
+/* Only intel systems have these runtime switches today. */
+#if (CCSHA1_VNG_INTEL || CCSHA2_VNG_INTEL || CCAES_INTEL_ASM) \
+    && (defined(__x86_64__) || defined(__i386__))
+
+#if CC_KERNEL
+    #include <i386/cpuid.h>
+    #define CC_HAS_AESNI() ((cpuid_features() & CPUID_FEATURE_AES) != 0)
+    #define CC_HAS_SupplementalSSE3() ((cpuid_features() & CPUID_FEATURE_SSSE3) != 0)
+    #define CC_HAS_AVX1() ((cpuid_features() & CPUID_FEATURE_AVX1_0) != 0)
+    #define CC_HAS_AVX2() ((cpuid_info()->cpuid_leaf7_features & CPUID_LEAF7_FEATURE_AVX2) != 0)
+    #define CC_HAS_AVX512_AND_IN_KERNEL()    ((cpuid_info()->cpuid_leaf7_features & CPUID_LEAF7_FEATURE_AVX512F) !=0)
+
+#elif CC_XNU_KERNEL_AVAILABLE
+    # include <System/i386/cpu_capabilities.h>
+
+    #ifndef kHasAVX2_0 /* 10.8 doesn't have kHasAVX2_0 defined */
+    #define kHasAVX2_0 0
+    #endif
+
+    extern int _cpu_capabilities;
+    #define CC_HAS_AESNI() (_cpu_capabilities & kHasAES)
+    #define CC_HAS_SupplementalSSE3() (_cpu_capabilities & kHasSupplementalSSE3)
+    #define CC_HAS_AVX1() (_cpu_capabilities & kHasAVX1_0)
+    #define CC_HAS_AVX2() (_cpu_capabilities & kHasAVX2_0)
+    #define CC_HAS_AVX512_AND_IN_KERNEL() 0
+#else
+    #define CC_HAS_AESNI() 0
+    #define CC_HAS_SupplementalSSE3() 0
+    #define CC_HAS_AVX1() 0
+    #define CC_HAS_AVX2() 0
+    #define CC_HAS_AVX512_AND_IN_KERNEL()  0
+#endif
+
+#endif /* !(defined(__x86_64__) || defined(__i386__)) */
+
+#endif /* CORECRYPTO_CC_RUNTIME_CONFIG_H_ */

--- a/include/corecrypto/ccaes.h
+++ b/include/corecrypto/ccaes.h
@@ -19,6 +19,8 @@
 #define CCAES_KEY_SIZE_192 24
 #define CCAES_KEY_SIZE_256 32
 
+#define CCAES_CTR_MAX_PARALLEL_NBLOCKS 8
+
 extern const struct ccmode_ecb ccaes_ltc_ecb_decrypt_mode;
 extern const struct ccmode_ecb ccaes_ltc_ecb_encrypt_mode;
 
@@ -43,11 +45,19 @@ extern const struct ccmode_ofb ccaes_arm_ofb_crypt_mode;
 #endif
 
 #if CCAES_MUX
+/* Runtime check to see if hardware should be used */
+int ccaes_ios_hardware_enabled(int operation);
+
 extern const struct ccmode_cbc ccaes_ios_hardware_cbc_encrypt_mode;
 extern const struct ccmode_cbc ccaes_ios_hardware_cbc_decrypt_mode;
 
+extern const struct ccmode_ctr ccaes_ios_hardware_ctr_crypt_mode;
+
 extern const struct ccmode_cbc *ccaes_ios_mux_cbc_encrypt_mode(void);
 extern const struct ccmode_cbc *ccaes_ios_mux_cbc_decrypt_mode(void);
+
+extern const struct ccmode_ctr *ccaes_ios_mux_ctr_crypt_mode(void);
+
 #endif
 
 #if  CCAES_INTEL_ASM
@@ -79,6 +89,15 @@ extern const struct ccmode_xts ccaes_intel_xts_decrypt_opt_mode;
 extern const struct ccmode_xts ccaes_intel_xts_decrypt_aesni_mode;
 #endif
 
+#if CC_USE_L4
+extern const struct ccmode_cbc ccaes_skg_cbc_encrypt_mode;
+extern const struct ccmode_cbc ccaes_skg_cbc_decrypt_mode;
+
+extern const struct ccmode_ecb ccaes_skg_ecb_encrypt_mode;
+extern const struct ccmode_ecb ccaes_skg_ecb_decrypt_mode;
+
+extern const struct ccmode_ecb ccaes_trng_ecb_encrypt_mode;
+#endif
 
 /* Implementation Selectors: */
 const struct ccmode_ecb *ccaes_ecb_encrypt_mode(void);

--- a/include/corecrypto/ccasn1.h
+++ b/include/corecrypto/ccasn1.h
@@ -69,26 +69,16 @@ enum {
     CCASN1_CONSTRUCTED_SEQUENCE = CCASN1_SEQUENCE | CCASN1_CONSTRUCTED,
 };
 
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-typedef union {
-    const unsigned char * oid;
-} __attribute__((transparent_union)) ccoid_t;
-#define CCOID(x) ((x).oid)
-#else
-    typedef const unsigned char * ccoid_t;
+typedef const unsigned char * ccoid_t;
 #define CCOID(oid) (oid)
-#endif
-
-/* Returns *der iff *der points to a DER encoded oid that fits within *der_len. */
-ccoid_t ccoid_for_der(size_t *der_len, const uint8_t **der);
 
 /* Returns the size of an oid including it's tag and length. */
-CC_INLINE CC_PURE CC_NONNULL_TU((1))
+CC_INLINE CC_PURE CC_NONNULL((1))
 size_t ccoid_size(ccoid_t oid) {
     return 2 + CCOID(oid)[1];
 }
 
-CC_INLINE CC_PURE CC_NONNULL((1)) CC_NONNULL((2))
+CC_INLINE CC_PURE CC_NONNULL((1, 2))
 bool ccoid_equal(ccoid_t oid1, ccoid_t oid2) {
     return  (ccoid_size(oid1) == ccoid_size(oid2)
             && memcmp(CCOID(oid1), CCOID(oid2), ccoid_size(oid1))== 0);

--- a/include/corecrypto/ccchacha20poly1305.h
+++ b/include/corecrypto/ccchacha20poly1305.h
@@ -1,0 +1,293 @@
+/*
+	ccchacha20poly1305.h
+	corecrypto
+
+	Copyright 2014 Apple Inc. All rights reserved.
+*/
+
+#ifndef _CORECRYPTO_CCCHACHA20POLY1305_H_
+#define _CORECRYPTO_CCCHACHA20POLY1305_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define CCCHACHA20_KEY_NBYTES 32
+#define CCCHACHA20_BLOCK_NBYTES 64
+#define CCCHACHA20_BLOCK_NBITS (CCCHACHA20_BLOCK_NBYTES * 8)
+#define CCCHACHA20_NONCE_NBYTES 12
+
+typedef struct {
+	uint32_t state[16];
+	uint8_t	buffer[CCCHACHA20_BLOCK_NBYTES];
+	size_t leftover;
+} ccchacha20_ctx;
+
+#define CCPOLY1305_TAG_NBYTES 16
+
+typedef struct {
+	uint32_t r0, r1, r2, r3, r4;
+	uint32_t s1, s2, s3, s4;
+	uint32_t h0, h1, h2, h3, h4;
+	uint8_t	buf[16];
+	size_t buf_used;
+	uint8_t	key[16];
+} ccpoly1305_ctx;
+
+
+/*!
+ @group		ccchacha20poly1305
+ @abstract	Encrypts and authenticates or decrypts and verifies data.
+ @discussion	See RFC 7539 for details.
+
+ @warning The key-nonce pair must be unique per encryption.
+
+ @warning A single message can be at most (2^38 - 64) bytes in length.
+
+ The correct sequence of calls to encrypt is:
+
+ @code ccchacha20poly1305_init(...)
+ ccchacha20poly1305_setnonce(...)
+ ccchacha20poly1305_aad(...)       (may be called zero or more times)
+ ccchacha20poly1305_encrypt(...)   (may be called zero or more times)
+ ccchacha20poly1305_finalize(...)
+
+ To reuse the context for additional encryptions, follow this sequence:
+
+ @code ccchacha20poly1305_reset(...)
+ ccchacha20poly1305_setnonce(...)
+ ccchacha20poly1305_aad(...)       (may be called zero or more times)
+ ccchacha20poly1305_encrypt(...)   (may be called zero or more times)
+ ccchacha20poly1305_finalize(...)
+
+ To decrypt, follow this call sequence:
+
+ @code ccchacha20poly1305_init(...)
+ ccchacha20poly1305_setnonce(...)
+ ccchacha20poly1305_aad(...)       (may be called zero or more times)
+ ccchacha20poly1305_decrypt(...)   (may be called zero or more times)
+ ccchacha20poly1305_verify(...)    (returns zero on successful decryption)
+
+ To reuse the context for additional encryptions, follow this sequence:
+
+ @code ccchacha20poly1305_reset(...)
+ ccchacha20poly1305_setnonce(...)
+ ccchacha20poly1305_aad(...)       (may be called zero or more times)
+ ccchacha20poly1305_decrypt(...)   (may be called zero or more times)
+ ccchacha20poly1305_verify(...)    (returns zero on successful decryption)
+*/
+
+#define CCCHACHA20POLY1305_KEY_NBYTES (CCCHACHA20_KEY_NBYTES)
+#define CCCHACHA20POLY1305_NONCE_NBYTES (CCCHACHA20_NONCE_NBYTES)
+#define CCCHACHA20POLY1305_TAG_NBYTES (CCPOLY1305_TAG_NBYTES)
+
+/* (2^32 - 1) blocks */
+/* (2^38 - 64) bytes */
+/* (2^41 - 512) bits */
+/* Exceeding this figure breaks confidentiality and authenticity. */
+#define CCCHACHA20POLY1305_TEXT_MAX_NBYTES ((1ULL << 38) - 64ULL)
+
+#define CCCHACHA20POLY1305_STATE_SETNONCE 1
+#define CCCHACHA20POLY1305_STATE_AAD 2
+#define CCCHACHA20POLY1305_STATE_ENCRYPT 3
+#define CCCHACHA20POLY1305_STATE_DECRYPT 4
+#define CCCHACHA20POLY1305_STATE_FINAL 5
+
+typedef struct {
+	ccchacha20_ctx chacha20_ctx;
+	ccpoly1305_ctx poly1305_ctx;
+	uint64_t aad_nbytes;
+	uint64_t text_nbytes;
+    uint8_t state;
+} ccchacha20poly1305_ctx;
+
+// This is just a stub right now.
+// Eventually we will optimize by platform.
+struct ccchacha20poly1305_info {
+
+};
+
+const struct ccchacha20poly1305_info *ccchacha20poly1305_info(void);
+
+/*!
+ @function   ccchacha20poly1305_init
+ @abstract   Initialize a chacha20poly1305 context.
+
+ @param      info       Implementation descriptor
+ @param      ctx        Context for this instance
+ @param      key        Secret chacha20 key
+
+ @result     0 iff successful.
+
+ @discussion The key is 32 bytes in length.
+
+ @warning The key-nonce pair must be unique per encryption.
+ */
+int	ccchacha20poly1305_init(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, const uint8_t *key);
+
+/*!
+ @function   ccchacha20poly1305_reset
+ @abstract   Reset a chacha20poly1305 context for reuse.
+
+ @param      info       Implementation descriptor
+ @param      ctx        Context for this instance
+
+ @result     0 iff successful.
+ */
+int ccchacha20poly1305_reset(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx);
+
+/*!
+ @function   ccchacha20poly1305_setnonce
+ @abstract   Set the nonce for encryption or decryption.
+
+ @param      info       Implementation descriptor
+ @param      ctx        Context for this instance
+ @param      nonce      Unique nonce per encryption
+
+ @result     0 iff successful.
+
+ @discussion The nonce is 12 bytes in length.
+
+ @warning The key-nonce pair must be unique per encryption.
+ */
+int ccchacha20poly1305_setnonce(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, const uint8_t *nonce);
+int ccchacha20poly1305_incnonce(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, uint8_t *nonce);
+
+/*!
+ @function   ccchacha20poly1305_aad
+ @abstract   Authenticate additional data.
+
+ @param      info       Descriptor for the mode
+ @param      ctx        Context for this instance
+ @param      nbytes     Length of the additional data in bytes
+ @param      aad        Additional data to authenticate
+
+ @result     0 iff successful.
+
+ @discussion This is typically used to authenticate data that cannot be encrypted (e.g. packet headers).
+
+ This function may be called zero or more times.
+ */
+int	ccchacha20poly1305_aad(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, size_t nbytes, const void *aad);
+
+/*!
+ @function   ccchacha20poly1305_encrypt
+ @abstract   Encrypt data.
+
+ @param      info       Descriptor for the mode
+ @param      ctx        Context for this instance
+ @param      nbytes     Length of the plaintext in bytes
+ @param      ptext      Input plaintext
+ @param      ctext      Output ciphertext
+
+ @result     0 iff successful.
+
+ @discussion In-place processing is supported.
+
+ This function may be called zero or more times.
+ */
+int	ccchacha20poly1305_encrypt(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, size_t nbytes, const void *ptext, void *ctext);
+
+/*!
+ @function   ccchacha20poly1305_finalize
+ @abstract   Finalize encryption.
+
+ @param      info       Descriptor for the mode
+ @param      ctx        Context for this instance
+ @param      tag        Generated authentication tag
+
+ @result     0 iff successful.
+
+ @discussion The generated tag is 16 bytes in length.
+ */
+int	ccchacha20poly1305_finalize(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, uint8_t *tag);
+
+/*!
+ @function   ccchacha20poly1305_decrypt
+ @abstract   Decrypt data.
+
+ @param      info       Descriptor for the mode
+ @param      ctx        Context for this instance
+ @param      nbytes     Length of the ciphertext in bytes
+ @param      ctext      Input ciphertext
+ @param      ptext      Output plaintext
+
+ @result     0 iff successful.
+
+ @discussion In-place processing is supported.
+
+ This function may be called zero or more times.
+ */
+int	ccchacha20poly1305_decrypt(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, size_t nbytes, const void *ctext, void *ptext);
+
+/*!
+ @function   ccchacha20poly1305_verify
+ @abstract   Verify authenticity.
+
+ @param      info       Descriptor for the mode
+ @param      ctx        Context for this instance
+ @param      tag        Expected authentication tag
+
+ @result     0 iff authentic and otherwise successful.
+
+ @discussion The expected tag is 16 bytes in length.
+ */
+int	ccchacha20poly1305_verify(const struct ccchacha20poly1305_info *info, ccchacha20poly1305_ctx *ctx, const uint8_t *tag);
+
+/*!
+ @function      ccchacha20poly1305_encrypt_oneshot
+ @abstract      Encrypt with chacha20poly1305.
+
+ @param      info           Descriptor for the mode
+ @param      key            Secret chacha20 key
+ @param      nonce          Unique nonce per encryption
+ @param      aad_nbytes     Length of the additional data in bytes
+ @param      aad            Additional data to authenticate
+ @param      ptext_nbytes   Length of the plaintext in bytes
+ @param      ptext          Input plaintext
+ @param      ctext          Output ciphertext
+ @param      tag            Generated authentication tag
+
+ @discussion See RFC 7539 for details.
+
+ The key is 32 bytes in length.
+
+ The nonce is 12 bytes in length.
+
+ The generated tag is 16 bytes in length.
+
+ In-place processing is supported.
+
+ @warning The key-nonce pair must be unique per encryption.
+
+ @warning A single message can be at most (2^38 - 64) bytes in length.
+ */
+int ccchacha20poly1305_encrypt_oneshot(const struct ccchacha20poly1305_info *info, const uint8_t *key, const uint8_t *nonce, size_t aad_nbytes, const void *aad, size_t ptext_nbytes, const void *ptext, void *ctext, uint8_t *tag);
+
+/*!
+ @function      ccchacha20poly1305_decrypt_oneshot
+ @abstract      Decrypt with chacha20poly1305.
+
+ @param      info           Descriptor for the mode
+ @param      key            Secret chacha20 key
+ @param      nonce          Unique nonce per encryption
+ @param      aad_nbytes     Length of the additional data in bytes
+ @param      aad            Additional data to authenticate
+ @param      ctext_nbytes   Length of the ciphertext in bytes
+ @param      ctext          Input ciphertext
+ @param      ptext          Output plaintext
+ @param      tag            Expected authentication tag
+
+ @discussion See RFC 7539 for details.
+
+ The key is 32 bytes in length.
+
+ The nonce is 12 bytes in length.
+
+ The generated tag is 16 bytes in length.
+
+ In-place processing is supported.
+ */
+int ccchacha20poly1305_decrypt_oneshot(const struct ccchacha20poly1305_info *info, const uint8_t *key, const uint8_t *nonce, size_t aad_nbytes, const void *aad, size_t ctext_nbytes, const void *ctext, void *ptext, const uint8_t *tag);
+
+#endif

--- a/include/corecrypto/cccmac.h
+++ b/include/corecrypto/cccmac.h
@@ -17,30 +17,6 @@
 
 #define CMAC_BLOCKSIZE   16
 
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-struct cccmac_ctx {
-    uint8_t b[8];
-} CC_ALIGNED(8);
-
-typedef struct cccmac_ctx_hdr {
-    uint8_t k1[CMAC_BLOCKSIZE];
-    uint8_t k2[CMAC_BLOCKSIZE];
-    uint8_t block[CMAC_BLOCKSIZE];
-    size_t  block_nbytes;      // Number of byte occupied in block buf
-    size_t  cumulated_nbytes;  // Total size processed
-    const struct ccmode_cbc *cbc;
-    uint8_t ctx[8];
-} CC_ALIGNED(8) cccmac_ctx_hdr;
-
-
-typedef union {
-    struct cccmac_ctx *b;
-    cccmac_ctx_hdr *hdr;
-} cccmac_ctx_t __attribute__((transparent_union));
-#define cccmac_hdr_size sizeof(struct cccmac_ctx_hdr)
-
-#else
-
 struct cccmac_ctx {
     uint8_t k1[CMAC_BLOCKSIZE];
     uint8_t k2[CMAC_BLOCKSIZE];
@@ -55,8 +31,6 @@ typedef struct cccmac_ctx* cccmac_ctx_t;
 
 #define cccmac_hdr_size sizeof(struct cccmac_ctx)
 
-#endif
-
 
 #define cccmac_iv_size(_mode_)  ((_mode_)->block_size)
 #define cccmac_cbc_size(_mode_) ((_mode_)->size)
@@ -67,15 +41,9 @@ typedef struct cccmac_ctx* cccmac_ctx_t;
 #define cccmac_mode_decl(_mode_, _name_) cc_ctx_decl(struct cccmac_ctx, cccmac_ctx_size(_mode_), _name_)
 #define cccmac_mode_clear(_mode_, _name_) cc_clear(cccmac_ctx_size(_mode_), _name_)
 
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-/* Return a cccbc_ctx * which can be accesed with the macros in ccmode.h */
-#define cccmac_mode_ctx_start(_mode_, HC)     (((HC).hdr)->ctx)
-#define CCCMAC_HDR(HC)      (((cccmac_ctx_t)(HC)).hdr)
-#else
 /* Return a cccbc_ctx * which can be accesed with the macros in ccmode.h */
 #define cccmac_mode_ctx_start(_mode_, HC)    (HC->ctx)
 #define CCCMAC_HDR(HC)      (HC)
-#endif
 
 #define cccmac_mode_sym_ctx(_mode_, HC)     (cccbc_ctx *)(cccmac_mode_ctx_start(_mode_, HC))
 #define cccmac_mode_iv(_mode_, HC)     (cccbc_iv *)(cccmac_mode_ctx_start(_mode_, HC)+cccmac_cbc_size(_mode_))
@@ -88,16 +56,6 @@ typedef struct cccmac_ctx* cccmac_ctx_t;
 
 
 /* CMAC as defined in NIST SP800-38B - 2005 */
-
-/* HACK: 
- To change the prototype of cccmac_init (and preserve the name) we need to
- proceed in steps:
- 1) Make corecrypto change (23557380)
- 2) Have all clients define "CC_CHANGEFUNCTION_28544056_cccmac_init"
- 3) Remove CC_CHANGEFUNCTION_28544056_cccmac_init logic and old functions of corecrypto
- 4) Clients can remove CC_CHANGEFUNCTION_28544056_cccmac_init at their leisure
- 
- */
 
 /* =============================================================================
 
@@ -169,25 +127,9 @@ int cccmac_one_shot_verify(const struct ccmode_cbc *cbc,
  @discussion Only supports CMAC_BLOCKSIZE block ciphers
  */
 
-
-
-#ifndef CC_CHANGEFUNCTION_28544056_cccmac_init
-int cccmac_init(const struct ccmode_cbc *cbc,
-                  cccmac_ctx_t ctx,
-                  size_t key_nbytes, const void *key)
-__attribute__((deprecated("see guidelines in corecrypto/cccmac.h for migration", "define 'CC_CHANGEFUNCTION_28544056_cccmac_init' and use new cccmac_init with parameter key_nbytes")));
-// If you see this deprecate warning
-// Define CC_CHANGEFUNCTION_28544056_cccmac_init and use "cccmac_init(...,...,16,...)"
-// This will be removed with 28544056
-#define cccmac_init(cbc,ctx,key) cccmac_init(cbc,ctx,16,key)
-
-#else
-
-// This is the authoritative prototype, which will be left after 28544056
 int cccmac_init(const struct ccmode_cbc *cbc,
                 cccmac_ctx_t ctx,
                 size_t key_nbytes, const void *key);
-#endif
 
 /*!
  @function   cccmac_update
@@ -234,71 +176,5 @@ int cccmac_final_generate(cccmac_ctx_t ctx,
  */
 int cccmac_final_verify(cccmac_ctx_t ctx,
                         size_t expected_mac_nbytes, const void *expected_mac);
-
-
-/* =============================================================================
-
- Legacy - Please migrate to new functions above
-
- ==============================================================================*/
-
-/*
- Guidelines for switching to new CMAC functions
-
- Legacy                        New functions
- cccmac_init         -> cccmac_init w/ key kength in bytes
- cccmac_block_update -> cccmac_update w/ size in bytes instead of blocks
- cccmac_final        -> cccmac_final_generate or cccmac_final_verify
- depending the use case preceeded
- by cccmac_update if any leftover bytes.
- cccmac              -> cccmac_one_shot_generate or cccmac_one_shot_verify
- depending the use case
-
- */
-
-/*!
- @function   cccmac_block_update
- @abstract   Process data
- */
-
-CC_INLINE void cccmac_block_update(CC_UNUSED const struct ccmode_cbc *cbc, cccmac_ctx_t ctx,
-                         size_t nblocks, const void *data)
-__attribute__((deprecated("see guidelines in corecrypto/cccmac.h for migration", "cccmac_update")));
-
-CC_INLINE void cccmac_block_update(CC_UNUSED const struct ccmode_cbc *cbc, cccmac_ctx_t ctx,
-                                   size_t nblocks, const void *data) {
-    cccmac_update(ctx,(nblocks)*CMAC_BLOCKSIZE,data);
-}
-
-/*!
- @function   cccmac_final
- @abstract   Finalize CMAC generation
- */
-CC_INLINE void cccmac_final(CC_UNUSED const struct ccmode_cbc *cbc, cccmac_ctx_t ctx,
-                            size_t nbytes, const void *in, void *out)
-__attribute__((deprecated("see guidelines in corecrypto/cccmac.h for migration", "cccmac_final_generate or cccmac_final_verify")));
-
-CC_INLINE void cccmac_final(CC_UNUSED const struct ccmode_cbc *cbc, cccmac_ctx_t ctx,
-                 size_t nbytes, const void *in, void *out) {
-    cccmac_update(ctx, nbytes, in);
-    cccmac_final_generate(ctx,CMAC_BLOCKSIZE,out);
-}
-
-/*!
- @function   cccmac
- @abstract   One shot CMAC generation with 128bit key
- */
-CC_INLINE void cccmac(const struct ccmode_cbc *cbc,
-                      const void *key,
-                      size_t data_len, const void *data, void *mac)
-__attribute__((deprecated("see guidelines in corecrypto/cccmac.h for migration", "cccmac_one_shot_generate or cccmac_one_shot_verify")));
-
-CC_INLINE void cccmac(const struct ccmode_cbc *cbc,
-           const void *key,
-           size_t data_len, const void *data, void *mac) {
-    cccmac_one_shot_generate(cbc,16,key,data_len,data,16,mac);
-}
-
-
 
 #endif /* _CORECRYPTO_cccmac_H_ */

--- a/include/corecrypto/ccder.h
+++ b/include/corecrypto/ccder.h
@@ -17,82 +17,76 @@
 #define CCDER_MULTIBYTE_TAGS  1
 
 #ifdef CCDER_MULTIBYTE_TAGS
- #if defined(_MSC_VER)
-   //TODO related to rdar://problem/24868013
-   typedef int ccder_tag; //MSVC forces enums to be ints
-  #else
-   typedef unsigned long ccder_tag;
-  #endif
+typedef unsigned long ccder_tag;
 #else
 typedef uint8_t ccder_tag;
 #endif
 
 /* DER types to be used with ccder_decode and ccder_encode functions. */
-enum {
-    CCDER_EOL               = CCASN1_EOL,
-    CCDER_BOOLEAN           = CCASN1_BOOLEAN,
-    CCDER_INTEGER           = CCASN1_INTEGER,
-    CCDER_BIT_STRING        = CCASN1_BIT_STRING,
-    CCDER_OCTET_STRING      = CCASN1_OCTET_STRING,
-    CCDER_NULL              = CCASN1_NULL,
-    CCDER_OBJECT_IDENTIFIER = CCASN1_OBJECT_IDENTIFIER,
-    CCDER_OBJECT_DESCRIPTOR = CCASN1_OBJECT_DESCRIPTOR,
+#define    CCDER_EOL               CCASN1_EOL
+#define    CCDER_BOOLEAN           CCASN1_BOOLEAN
+#define    CCDER_INTEGER           CCASN1_INTEGER
+#define    CCDER_BIT_STRING        CCASN1_BIT_STRING
+#define    CCDER_OCTET_STRING      CCASN1_OCTET_STRING
+#define    CCDER_NULL              CCASN1_NULL
+#define    CCDER_OBJECT_IDENTIFIER CCASN1_OBJECT_IDENTIFIER
+#define    CCDER_OBJECT_DESCRIPTOR CCASN1_OBJECT_DESCRIPTOR
     /* External or instance-of 0x08 */
-    CCDER_REAL              = CCASN1_REAL,
-    CCDER_ENUMERATED        = CCASN1_ENUMERATED,
-    CCDER_EMBEDDED_PDV      = CCASN1_EMBEDDED_PDV,
-    CCDER_UTF8_STRING       = CCASN1_UTF8_STRING,
+#define    CCDER_REAL              CCASN1_REAL
+#define    CCDER_ENUMERATED        CCASN1_ENUMERATED
+#define    CCDER_EMBEDDED_PDV      CCASN1_EMBEDDED_PDV
+#define    CCDER_UTF8_STRING       CCASN1_UTF8_STRING
     /*                         0x0d */
     /*                         0x0e */
     /*                         0x0f */
-    CCDER_SEQUENCE          = CCASN1_SEQUENCE,
-    CCDER_SET               = CCASN1_SET,
-    CCDER_NUMERIC_STRING    = CCASN1_NUMERIC_STRING,
-    CCDER_PRINTABLE_STRING  = CCASN1_PRINTABLE_STRING,
-    CCDER_T61_STRING        = CCASN1_T61_STRING,
-    CCDER_VIDEOTEX_STRING   = CCASN1_VIDEOTEX_STRING,
-    CCDER_IA5_STRING        = CCASN1_IA5_STRING,
-    CCDER_UTC_TIME          = CCASN1_UTC_TIME,
-    CCDER_GENERALIZED_TIME  = CCASN1_GENERALIZED_TIME,
-    CCDER_GRAPHIC_STRING    = CCASN1_GRAPHIC_STRING,
-    CCDER_VISIBLE_STRING    = CCASN1_VISIBLE_STRING,
-    CCDER_GENERAL_STRING    = CCASN1_GENERAL_STRING,
-    CCDER_UNIVERSAL_STRING  = CCASN1_UNIVERSAL_STRING,
+#define    CCDER_SEQUENCE          CCASN1_SEQUENCE
+#define    CCDER_SET               CCASN1_SET
+#define    CCDER_NUMERIC_STRING    CCASN1_NUMERIC_STRING
+#define    CCDER_PRINTABLE_STRING  CCASN1_PRINTABLE_STRING
+#define    CCDER_T61_STRING        CCASN1_T61_STRING
+#define    CCDER_VIDEOTEX_STRING   CCASN1_VIDEOTEX_STRING
+#define    CCDER_IA5_STRING        CCASN1_IA5_STRING
+#define    CCDER_UTC_TIME          CCASN1_UTC_TIME
+#define    CCDER_GENERALIZED_TIME  CCASN1_GENERALIZED_TIME
+#define    CCDER_GRAPHIC_STRING    CCASN1_GRAPHIC_STRING
+#define    CCDER_VISIBLE_STRING    CCASN1_VISIBLE_STRING
+#define    CCDER_GENERAL_STRING    CCASN1_GENERAL_STRING
+#define    CCDER_UNIVERSAL_STRING  CCASN1_UNIVERSAL_STRING
     /*                         0x1d */
-    CCDER_BMP_STRING        = CCASN1_BMP_STRING,
-    CCDER_HIGH_TAG_NUMBER   = CCASN1_HIGH_TAG_NUMBER,
-    CCDER_TELETEX_STRING    = CCDER_T61_STRING,
+#define    CCDER_BMP_STRING        CCASN1_BMP_STRING
+#define    CCDER_HIGH_TAG_NUMBER   CCASN1_HIGH_TAG_NUMBER
+#define    CCDER_TELETEX_STRING    CCDER_T61_STRING
 
 #ifdef CCDER_MULTIBYTE_TAGS
-    CCDER_TAG_MASK          = ((ccder_tag)~0),
-    CCDER_TAGNUM_MASK       = ((ccder_tag)~((ccder_tag)7 << (sizeof(ccder_tag) * 8 - 3))),
+#define    CCDER_TAG_MASK          ((ccder_tag)~0)
+#define    CCDER_TAGNUM_MASK       ((ccder_tag)~((ccder_tag)7 << (sizeof(ccder_tag) * 8 - 3)))
 
-    CCDER_METHOD_MASK       = ((ccder_tag)1 << (sizeof(ccder_tag) * 8 - 3)),
-    CCDER_PRIMITIVE         = ((ccder_tag)0 << (sizeof(ccder_tag) * 8 - 3)),
-    CCDER_CONSTRUCTED       = ((ccder_tag)1 << (sizeof(ccder_tag) * 8 - 3)),
+#define    CCDER_METHOD_MASK       ((ccder_tag)1 << (sizeof(ccder_tag) * 8 - 3))
+#define    CCDER_PRIMITIVE         ((ccder_tag)0 << (sizeof(ccder_tag) * 8 - 3))
+#define    CCDER_CONSTRUCTED       ((ccder_tag)1 << (sizeof(ccder_tag) * 8 - 3))
 
-    CCDER_CLASS_MASK        = ((ccder_tag)3 << (sizeof(ccder_tag) * 8 - 2)),
-    CCDER_UNIVERSAL         = ((ccder_tag)0 << (sizeof(ccder_tag) * 8 - 2)),
-    CCDER_APPLICATION       = ((ccder_tag)1 << (sizeof(ccder_tag) * 8 - 2)),
-    CCDER_CONTEXT_SPECIFIC  = ((ccder_tag)2 << (sizeof(ccder_tag) * 8 - 2)),
-    CCDER_PRIVATE           = ((ccder_tag)3 << (sizeof(ccder_tag) * 8 - 2)),
-#else
-    CCDER_TAG_MASK			= CCASN1_TAG_MASK,
-    CCDER_TAGNUM_MASK		= CCASN1_TAGNUM_MASK,
+#define    CCDER_CLASS_MASK        ((ccder_tag)3 << (sizeof(ccder_tag) * 8 - 2))
+#define    CCDER_UNIVERSAL         ((ccder_tag)0 << (sizeof(ccder_tag) * 8 - 2))
+#define    CCDER_APPLICATION       ((ccder_tag)1 << (sizeof(ccder_tag) * 8 - 2))
+#define    CCDER_CONTEXT_SPECIFIC  ((ccder_tag)2 << (sizeof(ccder_tag) * 8 - 2))
+#define    CCDER_PRIVATE           ((ccder_tag)3 << (sizeof(ccder_tag) * 8 - 2))
+#else /* !CCDER_MULTIBYTE_TAGS */
+#define    CCDER_TAG_MASK			CCASN1_TAG_MASK
+#define    CCDER_TAGNUM_MASK		CCASN1_TAGNUM_MASK
 
-    CCDER_METHOD_MASK		= CCASN1_METHOD_MASK,
-    CCDER_PRIMITIVE         = CCASN1_PRIMITIVE,
-    CCDER_CONSTRUCTED		= CCASN1_CONSTRUCTED,
+#define    CCDER_METHOD_MASK		CCASN1_METHOD_MASK
+#define    CCDER_PRIMITIVE          CCASN1_PRIMITIVE
+#define    CCDER_CONSTRUCTED		CCASN1_CONSTRUCTED
 
-    CCDER_CLASS_MASK		= CCASN1_CLASS_MASK,
-    CCDER_UNIVERSAL         = CCASN1_UNIVERSAL,
-    CCDER_APPLICATION		= CCASN1_APPLICATION,
-    CCDER_CONTEXT_SPECIFIC	= CCASN1_CONTEXT_SPECIFIC,
-    CCDER_PRIVATE			= CCASN1_PRIVATE,
-#endif
-    CCDER_CONSTRUCTED_SET   = CCDER_SET | CCDER_CONSTRUCTED,
-    CCDER_CONSTRUCTED_SEQUENCE = CCDER_SEQUENCE | CCDER_CONSTRUCTED,
-};
+#define    CCDER_CLASS_MASK		    CCASN1_CLASS_MASK
+#define    CCDER_UNIVERSAL          CCASN1_UNIVERSAL
+#define    CCDER_APPLICATION		CCASN1_APPLICATION
+#define    CCDER_CONTEXT_SPECIFIC	CCASN1_CONTEXT_SPECIFIC
+#define    CCDER_PRIVATE			CCASN1_PRIVATE
+#endif /* !CCDER_MULTIBYTE_TAGS */
+#define    CCDER_CONSTRUCTED_SET    (CCDER_SET | CCDER_CONSTRUCTED)
+#define    CCDER_CONSTRUCTED_SEQUENCE (CCDER_SEQUENCE | CCDER_CONSTRUCTED)
+
 
 // MARK: ccder_sizeof_ functions
 
@@ -140,21 +134,21 @@ size_t ccder_sizeof_uint64(uint64_t value);
 /* Encode a tag backwards, der_end should point to one byte past the end of
    destination for the tag, returns a pointer to the first byte of the tag.
    Returns NULL if there is an encoding error. */
-CC_NONNULL2
+CC_NONNULL((2))
 uint8_t *ccder_encode_tag(ccder_tag tag, const uint8_t *der, uint8_t *der_end);
 
 /* Returns a pointer to the start of the len field.  returns NULL if there
  is an encoding error. */
-CC_NONNULL2
+CC_NONNULL((2))
 uint8_t *
 ccder_encode_len(size_t len, const uint8_t *der, uint8_t *der_end);
 
 /* der_end should point to the first byte of the content of this der item. */
-CC_NONNULL3
+CC_NONNULL((3))
 uint8_t *
 ccder_encode_tl(ccder_tag tag, size_t len, const uint8_t *der, uint8_t *der_end);
 
-CC_PURE CC_NONNULL2
+CC_PURE CC_NONNULL((2))
 uint8_t *
 ccder_encode_body_nocopy(size_t size, const uint8_t *der, uint8_t *der_end);
 
@@ -169,7 +163,7 @@ ccder_encode_constructed_tl(ccder_tag tag, const uint8_t *body_end,
 
 /* Encodes oid into der and returns
  der + ccder_sizeof_oid(oid). */
-CC_NONNULL_TU((1)) CC_NONNULL2
+CC_NONNULL((1, 2))
 uint8_t *ccder_encode_oid(ccoid_t oid, const uint8_t *der, uint8_t *der_end);
 
 CC_NONNULL((3, 4))
@@ -181,12 +175,12 @@ CC_NONNULL((2, 3))
 uint8_t *ccder_encode_integer(cc_size n, const cc_unit *s,
                               const uint8_t *der, uint8_t *der_end);
 
-CC_NONNULL3
+CC_NONNULL((3))
 uint8_t *ccder_encode_implicit_uint64(ccder_tag implicit_tag,
                                       uint64_t value,
                                       const uint8_t *der, uint8_t *der_end);
 
-CC_NONNULL2
+CC_NONNULL((2))
 uint8_t *ccder_encode_uint64(uint64_t value,
                              const uint8_t *der, uint8_t *der_end);
 
@@ -212,7 +206,7 @@ uint8_t *ccder_encode_raw_octet_string(size_t s_size, const uint8_t *s,
 
 size_t ccder_encode_eckey_size(size_t priv_size, ccoid_t oid, size_t pub_size);
 
-CC_NONNULL2 CC_NONNULL5 CC_NONNULL6  CC_NONNULL7
+CC_NONNULL((2, 5, 6, 7))
 uint8_t *ccder_encode_eckey(size_t priv_size, const uint8_t *priv_key,
                             ccoid_t oid,
                             size_t pub_size, const uint8_t *pub_key,
@@ -222,7 +216,7 @@ uint8_t *ccder_encode_eckey(size_t priv_size, const uint8_t *priv_key,
    It's inefficient – especially when you already have to convert to get to
    the form for the body.
    see encode integer for the right way to unify conversion and insertion */
-CC_NONNULL3
+CC_NONNULL((3))
 uint8_t *
 ccder_encode_body(size_t size, const uint8_t* body,
                   const uint8_t *der, uint8_t *der_end);
@@ -297,16 +291,16 @@ const uint8_t *ccder_decode_uint64(uint64_t* r,
 CC_NONNULL((2, 3, 5))
 const uint8_t *ccder_decode_seqii(cc_size n, cc_unit *r, cc_unit *s,
                                   const uint8_t *der, const uint8_t *der_end);
-CC_NONNULL_TU((1)) CC_NONNULL((3))
+CC_NONNULL((1, 3))
 const uint8_t *ccder_decode_oid(ccoid_t *oidp,
                                 const uint8_t *der, const uint8_t *der_end);
 
-CC_NONNULL((1,2,4))
+CC_NONNULL((1, 2, 4))
 const uint8_t *ccder_decode_bitstring(const uint8_t **bit_string,
                                 size_t *bit_length,
                                 const uint8_t *der, const uint8_t *der_end);
 
-CC_NONNULL_TU((4)) CC_NONNULL((1,2,3,5,6,8))
+CC_NONNULL((1, 2, 3, 4, 5, 6, 8))
 const uint8_t *ccder_decode_eckey(uint64_t *version,
                                   size_t *priv_size, const uint8_t **priv_key,
                                   ccoid_t *oid,

--- a/include/corecrypto/ccdes.h
+++ b/include/corecrypto/ccdes.h
@@ -17,12 +17,8 @@
 #define CCDES_BLOCK_SIZE 8
 #define CCDES_KEY_SIZE 8
 
-extern const struct ccmode_ecb ccdes_ltc_ecb_decrypt_mode;
-extern const struct ccmode_ecb ccdes_ltc_ecb_encrypt_mode;
-
 extern const struct ccmode_ecb ccdes3_ltc_ecb_decrypt_mode;
 extern const struct ccmode_ecb ccdes3_ltc_ecb_encrypt_mode;
-extern const struct ccmode_ecb ccdes168_ltc_ecb_encrypt_mode;
 
 const struct ccmode_ecb *ccdes_ecb_decrypt_mode(void);
 const struct ccmode_ecb *ccdes_ecb_encrypt_mode(void);
@@ -61,8 +57,8 @@ int ccdes_key_is_weak( void *key, size_t  length);
 void ccdes_key_set_odd_parity(void *key, size_t length);
 
 uint32_t
-ccdes_cbc_cksum(void *in, void *out, size_t length,
-                void *key, size_t keylen, void *ivec);
+ccdes_cbc_cksum(const void *in, void *out, size_t length,
+                const void *key, size_t key_nbytes, const void *ivec);
 
 
 #endif /* _CORECRYPTO_CCDES_H_ */

--- a/include/corecrypto/ccdigest_priv.h
+++ b/include/corecrypto/ccdigest_priv.h
@@ -14,14 +14,7 @@
 #include <corecrypto/ccdigest.h>
 #include <corecrypto/ccasn1.h>
 
-void ccdigest_final_common(const struct ccdigest_info *di,
-                           ccdigest_ctx_t ctx, void *digest);
-void ccdigest_final_64be(const struct ccdigest_info *di, ccdigest_ctx_t,
-                         unsigned char *digest);
-void ccdigest_final_64le(const struct ccdigest_info *di, ccdigest_ctx_t,
-                         unsigned char *digest);
-
-CC_INLINE CC_NONNULL_TU((1))
+CC_INLINE CC_NONNULL((1))
 bool ccdigest_oid_equal(const struct ccdigest_info *di, ccoid_t oid) {
     if(di->oid == NULL && CCOID(oid) == NULL) return true;
     if(di->oid == NULL || CCOID(oid) == NULL) return false;

--- a/include/corecrypto/ccdrbg.h
+++ b/include/corecrypto/ccdrbg.h
@@ -21,27 +21,17 @@
 #include <corecrypto/cc.h>
 #include <corecrypto/ccdrbg_impl.h>
 
-/* error codes */
-#define CCDRBG_STATUS_OK 0
-#define CCDRBG_STATUS_ERROR (-1)
-#define CCDRBG_STATUS_NEED_RESEED (-2)
-#define CCDRBG_STATUS_PARAM_ERROR (-3)
-// If this value is returned, the caller must abort or panic the process for security reasons.
-// for example in the case of catastrophic error in
-// http://csrc.nist.gov/publications/drafts/800-90/sp800_90a_r1_draft.pdf
-// ccdrbg calls abort() or panic(), if they are available in the system.
-#define CCDRBG_STATUS_ABORT (-4)
 /*
- * The maximum length of the entropy_input,  additional_input (max_additional_input_length) , personalization string 
+ * The maximum length of the entropy_input,  additional_input (max_additional_input_length) , personalization string
  * (max_personalization_string_length) and max_number_of_bits_per_request  are implementation dependent
- * but shall fit in a 32 bit register and be be less than or equal to the specified maximum length for the 
+ * but shall fit in a 32 bit register and be be less than or equal to the specified maximum length for the
  * selected DRBG mechanism (NIST 800-90A Section 10).
  */
 
 #define CCDRBG_MAX_ENTROPY_SIZE         ((uint32_t)1<<16)
 #define CCDRBG_MAX_ADDITIONALINPUT_SIZE ((uint32_t)1<<16)
 #define CCDRBG_MAX_PSINPUT_SIZE         ((uint32_t)1<<16)
-#define CCDRBG_MAX_REQUEST_SIZE         ((uint32_t)1<<16) //this is the the absolute maximum in NIST 800-90A
+#define CCDRBG_MAX_REQUEST_SIZE         ((uint32_t)1<<16) //this is the absolute maximum in NIST 800-90A
 #define CCDRBG_RESEED_INTERVAL          ((uint64_t)1<<30) // must be able to fit the NIST maximum of 2^48
 
 
@@ -87,18 +77,18 @@ CC_INLINE void ccdrbg_done(const struct ccdrbg_info *info,
 	info->done(drbg);
 }
 
-CC_INLINE size_t ccdrbg_context_size(const struct ccdrbg_info *drbg)
+CC_INLINE size_t ccdrbg_context_size(const struct ccdrbg_info *info)
 {
-    return drbg->size;
+    return info->size;
 }
 
 
 /*
  * NIST SP 800-90 CTR_DRBG
- * the mximum security strengh of drbg equals to the block size of the corresponding ECB.
+ * the maximum security strengh of drbg equals to the block size of the corresponding ECB.
  */
 struct ccdrbg_nistctr_custom {
-    const struct ccmode_ecb *ecb;
+    const struct ccmode_ctr *ctr_info;
     size_t keylen;
     int strictFIPS;
     int use_df;
@@ -110,19 +100,11 @@ void ccdrbg_factory_nistctr(struct ccdrbg_info *info, const struct ccdrbg_nistct
  * NIST SP 800-90 HMAC_DRBG
  * the maximum security strengh of drbg is half of output size of the input hash function and it internally is limited to 256 bits
  */
-extern struct ccdrbg_info ccdrbg_nistdigest_info;
-
 struct ccdrbg_nisthmac_custom {
     const struct ccdigest_info *di;
     int strictFIPS;
 };
 
 void ccdrbg_factory_nisthmac(struct ccdrbg_info *info, const struct ccdrbg_nisthmac_custom *custom);
-
-
-/*
- * Dummy DRBG
- */
-extern struct ccdrbg_info ccdrbg_dummy_info;
 
 #endif /* _CORECRYPTO_CCDRBG_H_ */

--- a/include/corecrypto/cchmac.h
+++ b/include/corecrypto/cchmac.h
@@ -19,10 +19,7 @@ struct cchmac_ctx {
     uint8_t b[8];
 } CC_ALIGNED(8);
 
-typedef union {
-    struct cchmac_ctx *hdr;
-    ccdigest_ctx_t digest;
-} cchmac_ctx_t __attribute__((transparent_union));
+typedef struct cchmac_ctx* cchmac_ctx_t;
 
 #define cchmac_ctx_size(STATE_SIZE, BLOCK_SIZE)  (ccdigest_ctx_size(STATE_SIZE, BLOCK_SIZE) + (STATE_SIZE))
 #define cchmac_di_size(_di_)  (cchmac_ctx_size((_di_)->state_size, (_di_)->block_size))
@@ -35,24 +32,25 @@ typedef union {
 #define cchmac_di_clear(_di_, _name_) cchmac_ctx_clear((_di_)->state_size, (_di_)->block_size, _name_)
 
 /* Return a ccdigest_ctx_t which can be accesed with the macros in ccdigest.h */
-#define cchmac_digest_ctx(_di_, HC)    (((cchmac_ctx_t)(HC)).digest)
+#define cchmac_digest_ctx(_di_, HC)    ((ccdigest_ctx_t)(HC))
 
 /* Accesors for ostate fields, this is all cchmac_ctx_t adds to the ccdigest_ctx_t. */
-#define cchmac_ostate(_di_, HC)    ((struct ccdigest_state *)(((cchmac_ctx_t)(HC)).hdr->b + ccdigest_di_size(_di_)))
+#define cchmac_ostate(_di_, HC)    ((struct ccdigest_state *)(((cchmac_ctx_t)(HC))->b + ccdigest_di_size(_di_)))
 #define cchmac_ostate8(_di_, HC)   (ccdigest_u8(cchmac_ostate(_di_, HC)))
 #define cchmac_ostate32(_di_, HC)  (ccdigest_u32(cchmac_ostate(_di_, HC)))
 #define cchmac_ostate64(_di_, HC)  (ccdigest_u64(cchmac_ostate(_di_, HC)))
 #define cchmac_ostateccn(_di_, HC) (ccdigest_ccn(cchmac_ostate(_di_, HC)))
 
 /* Convenience accessors for ccdigest_ctx_t fields. */
-#define cchmac_istate(_di_, HC)    ccdigest_state(_di_, ((cchmac_ctx_t)(HC)).digest)
+#define cchmac_istate(_di_, HC)    ccdigest_state(_di_, ((ccdigest_ctx_t)(HC)))
 #define cchmac_istate8(_di_, HC)   ccdigest_u8(cchmac_istate(_di_, HC))
 #define cchmac_istate32(_di_, HC)  ccdigest_u32(cchmac_istate(_di_, HC))
 #define cchmac_istate64(_di_, HC)  ccdigest_u64(cchmac_istate(_di_, HC))
 #define cchmac_istateccn(_di_, HC) ccdigest_ccn(cchmac_istate(_di_, HC))
-#define cchmac_data(_di_, HC)      ccdigest_data(_di_, ((cchmac_ctx_t)(HC)).digest)
-#define cchmac_num(_di_, HC)       ccdigest_num(_di_, ((cchmac_ctx_t)(HC)).digest)
-#define cchmac_nbits(_di_, HC)     ccdigest_nbits(_di_, ((cchmac_ctx_t)(HC)).digest)
+
+#define cchmac_data(_di_, HC)      ccdigest_data(_di_, ((ccdigest_ctx_t)(HC)))
+#define cchmac_num(_di_, HC)       ccdigest_num(_di_, ((ccdigest_ctx_t)(HC)))
+#define cchmac_nbits(_di_, HC)     ccdigest_nbits(_di_, ((ccdigest_ctx_t)(HC)))
 
 void cchmac_init(const struct ccdigest_info *di, cchmac_ctx_t ctx,
                  size_t key_len, const void *key);
@@ -64,21 +62,5 @@ void cchmac_final(const struct ccdigest_info *di, cchmac_ctx_t ctx,
 void cchmac(const struct ccdigest_info *di, size_t key_len,
             const void *key, size_t data_len, const void *data,
             unsigned char *mac);
-
-/* Test functions */
-
-struct cchmac_test_input {
-    const struct ccdigest_info *di;
-    size_t key_len;
-    const void *key;
-    size_t data_len;
-    const void *data;
-    size_t mac_len;
-    const void *expected_mac;
-};
-
-int cchmac_test(const struct cchmac_test_input *input);
-int cchmac_test_chunks(const struct cchmac_test_input *input, size_t chunk_size);
-
 
 #endif /* _CORECRYPTO_CCHMAC_H_ */

--- a/include/corecrypto/cckprng.h
+++ b/include/corecrypto/cckprng.h
@@ -1,0 +1,83 @@
+/*
+ *  cckprng.h
+ *  corecrypto
+ *
+ *  Created on 12/7/2017
+ *
+ *  Copyright (c) 2017 Apple Inc. All rights reserved.
+ *
+ */
+
+#ifndef _CORECRYPTO_CCKPRNG_H_
+#define _CORECRYPTO_CCKPRNG_H_
+
+#include <corecrypto/cc.h>
+
+typedef struct PRNG *PrngRef;
+typedef struct cckprng_ctx *cckprng_ctx_t;
+
+struct cckprng_ctx {
+    PrngRef prng;
+    uint64_t bytes_since_entropy;
+    uint64_t bytes_generated;
+};
+
+#define CCKPRNG_ENTROPY_INTERVAL (1 << 14)
+#define CCKPRNG_RESEED_NTICKS 50
+
+/*
+  @function cckprng_init
+  @abstract Initialize a kernel PRNG context.
+
+  @param ctx Context for this instance
+  @param nbytes Length of the seed in bytes
+  @param seed Pointer to a high-entropy seed
+
+  @result @p CCKPRNG_OK iff successful. Panic on @p CCKPRNG_ABORT.
+*/
+int cckprng_init(cckprng_ctx_t ctx, size_t nbytes, const void *seed);
+
+/*
+  @function cckprng_reseed
+  @abstract Reseed a kernel PRNG context immediately.
+
+  @param ctx Context for this instance
+  @param nbytes Length of the seed in bytes
+  @param seed Pointer to a high-entropy seed
+
+  @result @p CCKPRNG_OK iff successful. Panic on @p CCKPRNG_ABORT.
+*/
+int cckprng_reseed(cckprng_ctx_t ctx, size_t nbytes, const void *seed);
+
+/*
+  @function cckprng_addentropy
+  @abstract Add entropy to a kernel PRNG context.
+
+  @param ctx Context for this instance
+  @param nbytes Length of the input entropy in bytes
+  @param seed Pointer to input entropy
+
+  @result @p CCKPRNG_OK iff successful. Panic on @p CCKPRNG_ABORT.
+
+  @discussion Input entropy is stored internally and consumed at the
+  opportune moment. This will not necessarily be before the next call
+  to @p cckprng_generate. To force an immediate reseed, call @p
+  cckprng_reseed.
+*/
+int cckprng_addentropy(cckprng_ctx_t ctx, size_t nbytes, const void *entropy);
+
+/*
+  @function cckprng_generate
+  @abstract Generate random values for use in applications.
+
+  @param ctx Context for this instance
+  @param nbytes Length of the desired output in bytes
+  @param seed Pointer to the output buffer
+
+  @result @p CCKPRNG_OK iff successful. Panic on @p
+  CCKPRNG_ABORT. Provide input to @p cckprng_addentropy on @p
+  CCKPRNG_NEED_ENTROPY.
+*/
+int cckprng_generate(cckprng_ctx_t ctx, size_t nbytes, void *out);
+
+#endif /* _CORECRYPTO_CCKPRNG_H_ */

--- a/include/corecrypto/ccmd5.h
+++ b/include/corecrypto/ccmd5.h
@@ -17,8 +17,6 @@
 #define CCMD5_OUTPUT_SIZE  16
 #define CCMD5_STATE_SIZE   16
 
-extern const uint32_t ccmd5_initial_state[4];
-
 /* Selector */
 const struct ccdigest_info *ccmd5_di(void);
 

--- a/include/corecrypto/ccmode_factory.h
+++ b/include/corecrypto/ccmode_factory.h
@@ -14,7 +14,7 @@
 #include <corecrypto/ccn.h>  /* TODO: Remove dependency on this header. */
 #include <corecrypto/ccmode_impl.h>
 
-/* Function and macros defined in this file are only to be used 
+/* Function and macros defined in this file are only to be used
  within corecrypto files.
  */
 
@@ -83,68 +83,6 @@ const struct ccmode_xts *cc##_cipher_##_xts_##_dir_##_mode(void)                
     return &xts##_cipher_##_##_dir_;                                            \
 }
 
-#if 0
-
-/* example of how to make the selection function thread safe */
-
-struct ccmode_cbc cc3des_cbc_mode_encrypt;
-dispatch_once_t cc3des_mode_encrypt_init_once;
-
-void cc3des_mode_encrypt_init(void *ctx) {
-    struct ccmode_ecb *ecb = cc3des_ecb_encrypt_mode();
-    ccmode_factory_cbc_encrypt(&cc3des_mode_encrypt, ecb);
-}
-
-const struct ccmode_cbc *cc3des_cbc_encrypt_mode(void) {
-    dispatch_once_f(&cc3des_mode_encrypt_init_once, NULL, cc3des_mode_encrypt_init);
-    return &cc3des_mode_encrypt;
-}
-
-struct ccmode_cbc cc3des_cbc_mode_encrypt = {
-    .n = CC3DES_LTC_ECB_ENCRYPT_N,
-    .init = ccmode_cbc_init,
-    .cbc = ccmode_cbc_encrypt,
-    .custom = &cc3des_ltc_ecb_encrypt
-};
-
-const struct ccmode_cbc *cc3des_cbc_encrypt_mode(void) {
-    return &cc3des_mode_encrypt;
-}
-
-#endif
-
-
-
-int ccmode_cbc_init(const struct ccmode_cbc *cbc, cccbc_ctx *ctx,
-                    size_t rawkey_len, const void *rawkey);
-int ccmode_cbc_decrypt(const cccbc_ctx *ctx, cccbc_iv *iv, size_t nblocks,
-                       const void *in, void *out);
-int ccmode_cbc_encrypt(const cccbc_ctx *ctx, cccbc_iv *iv, size_t nblocks,
-                       const void *in, void *out);
-
-struct _ccmode_cbc_key {
-    const struct ccmode_ecb *ecb;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_cbc object for decryption. */
-#define CCMODE_FACTORY_CBC_DECRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_cbc_key)) + ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = (ECB)->block_size, \
-.init = ccmode_cbc_init, \
-.cbc = ccmode_cbc_decrypt, \
-.custom = (ECB) \
-}
-
-/* Use this to statically initialize a ccmode_cbc object for encryption. */
-#define CCMODE_FACTORY_CBC_ENCRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_cbc_key)) + ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = (ECB)->block_size, \
-.init = ccmode_cbc_init, \
-.cbc = ccmode_cbc_encrypt, \
-.custom = (ECB) \
-}
-
 /* Use these function to runtime initialize a ccmode_cbc decrypt object (for
  example if it's part of a larger structure). Normally you would pass a
  ecb decrypt mode implementation of some underlying algorithm as the ecb
@@ -160,37 +98,6 @@ void ccmode_factory_cbc_encrypt(struct ccmode_cbc *cbc,
                                 const struct ccmode_ecb *ecb);
 
 
-int ccmode_cfb_init(const struct ccmode_cfb *cfb, cccfb_ctx *ctx,
-                    size_t rawkey_len, const void *rawkey,
-                    const void *iv);
-int ccmode_cfb_decrypt(cccfb_ctx *ctx, size_t nbytes,
-                       const void *in, void *out);
-int ccmode_cfb_encrypt(cccfb_ctx *ctx, size_t nbytes,
-                       const void *in, void *out);
-struct _ccmode_cfb_key {
-    const struct ccmode_ecb *ecb;
-    size_t pad_len;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_cfb object for decryption. */
-#define CCMODE_FACTORY_CFB_DECRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_cfb_key)) + 2 * ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = 1, \
-.init = ccmode_cfb_init, \
-.cfb = ccmode_cfb_decrypt, \
-.custom = (ECB) \
-}
-
-/* Use this to statically initialize a ccmode_cfb object for encryption. */
-#define CCMODE_FACTORY_CFB_ENCRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_cfb_key)) + 2 * ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = 1, \
-.init = ccmode_cfb_init, \
-.cfb = ccmode_cfb_encrypt, \
-.custom = (ECB) \
-}
-
 /* Use these function to runtime initialize a ccmode_cfb decrypt object (for
  example if it's part of a larger structure). Normally you would pass a
  ecb encrypt mode implementation of some underlying algorithm as the ecb
@@ -204,36 +111,6 @@ void ccmode_factory_cfb_decrypt(struct ccmode_cfb *cfb,
  parameter. */
 void ccmode_factory_cfb_encrypt(struct ccmode_cfb *cfb,
                                 const struct ccmode_ecb *ecb);
-
-int ccmode_cfb8_init(const struct ccmode_cfb8 *cfb8, cccfb8_ctx *ctx,
-                     size_t rawkey_len, const void *rawkey, const void *iv);
-int ccmode_cfb8_decrypt(cccfb8_ctx *ctx, size_t nbytes,
-                        const void *in, void *out);
-int ccmode_cfb8_encrypt(cccfb8_ctx *ctx, size_t nbytes,
-                        const void *in, void *out);
-
-struct _ccmode_cfb8_key {
-    const struct ccmode_ecb *ecb;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_cfb8 object for decryption. */
-#define CCMODE_FACTORY_CFB8_DECRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_cfb8_key)) + 2 * ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = 1, \
-.init = ccmode_cfb8_init, \
-.cfb8 = ccmode_cfb8_decrypt, \
-.custom = (ECB) \
-}
-
-/* Use this to statically initialize a ccmode_cfb8 object for encryption. */
-#define CCMODE_FACTORY_CFB8_ENCRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_cfb8_key)) + 2 * ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = 1, \
-.init = ccmode_cfb8_init, \
-.cfb8 = ccmode_cfb8_encrypt, \
-.custom = (ECB) \
-}
 
 /* Use these function to runtime initialize a ccmode_cfb8 decrypt object (for
  example if it's part of a larger structure). Normally you would pass a
@@ -249,94 +126,12 @@ void ccmode_factory_cfb8_decrypt(struct ccmode_cfb8 *cfb8,
 void ccmode_factory_cfb8_encrypt(struct ccmode_cfb8 *cfb8,
                                  const struct ccmode_ecb *ecb);
 
-int ccmode_ctr_init(const struct ccmode_ctr *ctr, ccctr_ctx *ctx,
-                    size_t rawkey_len, const void *rawkey, const void *iv);
-int ccmode_ctr_crypt(ccctr_ctx *ctx, size_t nbytes,
-                     const void *in, void *out);
-
-struct _ccmode_ctr_key {
-    const struct ccmode_ecb *ecb;
-    size_t pad_len;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_ctr object for decryption. */
-#define CCMODE_FACTORY_CTR_CRYPT(ECB_ENCRYPT) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_ctr_key)) + 2 * ccn_sizeof_size((ECB_ENCRYPT)->block_size) + ccn_sizeof_size((ECB_ENCRYPT)->size), \
-.block_size = 1, \
-.init = ccmode_ctr_init, \
-.ctr = ccmode_ctr_crypt, \
-.custom = (ECB_ENCRYPT) \
-}
-
 /* Use these function to runtime initialize a ccmode_ctr decrypt object (for
  example if it's part of a larger structure). Normally you would pass a
  ecb encrypt mode implementation of some underlying algorithm as the ecb
  parameter. */
 void ccmode_factory_ctr_crypt(struct ccmode_ctr *ctr,
                               const struct ccmode_ecb *ecb);
-
-
-/* Create a gcm key from a gcm mode object.
- key must point to at least sizeof(CCMODE_GCM_KEY(ecb)) bytes of free
- storage. */
-int ccmode_gcm_init(const struct ccmode_gcm *gcm, ccgcm_ctx *ctx,
-                     size_t rawkey_len, const void *rawkey);
-int ccmode_gcm_set_iv(ccgcm_ctx *ctx, size_t iv_nbytes, const void *iv);
-int ccmode_gcm_aad(ccgcm_ctx *ctx, size_t nbytes, const void *in);
-int ccmode_gcm_decrypt(ccgcm_ctx *ctx, size_t nbytes, const void *in,
-                        void *out);
-int ccmode_gcm_encrypt(ccgcm_ctx *ctx, size_t nbytes, const void *in,
-                        void *out);
-
-/*!
- @function  ccmode_gcm_finalize() finalizes AES-GCM call sequence
- @param key encryption or decryption key
- @param tag_size
- @param tag
- @result	0=success or non zero= error
- @discussion For decryption, the tag parameter must be the expected-tag. A secure compare is performed between the provided expected-tag and the computed-tag. If they are the same, 0 is returned. Otherwise, non zero is returned. For encryption, tag is output and provides the authentication tag.
-
- */
-int ccmode_gcm_finalize(ccgcm_ctx *key, size_t tag_size, void *tag);
-int ccmode_gcm_reset(ccgcm_ctx *key);
-
-#define CCGCM_FLAGS_INIT_WITH_IV 1
-
-// Here is what the structure looks like in memory
-// [ temp space | length | *ecb | *ecb_key | table | ecb_key ]
-// size of table depends on the implementation (VNG vs factory)
-// currently, VNG and factory share the same "header" described here
-// VNG may add additional data after the header
-struct _ccmode_gcm_key {
-    // 5 blocks of temp space.
-    unsigned char H[16];       /* multiplier */
-    unsigned char X[16];       /* accumulator */
-    unsigned char Y[16];       /* counter */
-    unsigned char Y_0[16];     /* initial counter */
-    unsigned char buf[16];      /* buffer for stuff */
-
-    // State and length
-    uint16_t state;        /* state the GCM code is in */
-    uint16_t flags;        /* flags (persistent across reset) */
-    uint32_t buf_nbytes;   /* length of data in buf */
-
-    uint64_t aad_nbytes;   /* 64-bit counter used for IV and AAD */
-    uint64_t text_nbytes;  /* 64-bit counter for the plaintext PT */
-
-    // ECB
-    const struct ccmode_ecb *ecb;              // ecb mode
-    // Pointer to the ECB key in the buffer
-    void *ecb_key;                             // address of the ecb_key in u, set in init function
-    int encdec; //is it an encrypt or decrypt object
-
-    // Buffer with ECB key and H table if applicable
-    unsigned char u[] __attribute__ ((aligned (16))); // ecb key + tables
-};
-
-#define GCM_ECB_KEY_SIZE(ECB_ENCRYPT) \
-        ((5 * ccn_sizeof_size((ECB_ENCRYPT)->block_size)) \
-    + ccn_sizeof_size((ECB_ENCRYPT)->size))
 
 /* Use these function to runtime initialize a ccmode_gcm decrypt object (for
  example if it's part of a larger structure). For GCM you always pass a
@@ -351,72 +146,6 @@ void ccmode_factory_gcm_decrypt(struct ccmode_gcm *gcm,
  parameter. */
 void ccmode_factory_gcm_encrypt(struct ccmode_gcm *gcm,
                                 const struct ccmode_ecb *ecb_encrypt);
-
-
-/* CCM (only NIST approved with AES) */
-int ccmode_ccm_init(const struct ccmode_ccm *ccm, ccccm_ctx *ctx,
-                     size_t rawkey_len, const void *rawkey);
-int ccmode_ccm_set_iv(ccccm_ctx *ctx, ccccm_nonce *nonce_ctx, size_t nonce_len, const void *nonce,
-                       size_t mac_size, size_t auth_len, size_t data_len);
-/* internal function */
-void ccmode_ccm_macdata(ccccm_ctx *key, ccccm_nonce *nonce_ctx, unsigned new_block, size_t nbytes, const void *in);
-/* api function - disallows only mac'd data after data to encrypt was sent */
-int ccmode_ccm_cbcmac(ccccm_ctx *ctx, ccccm_nonce *nonce_ctx, size_t nbytes, const void *in);
-/* internal function */
-void ccmode_ccm_crypt(ccccm_ctx *key, ccccm_nonce *nonce_ctx, size_t nbytes, const void *in, void *out);
-int ccmode_ccm_decrypt(ccccm_ctx *ctx, ccccm_nonce *nonce_ctx, size_t nbytes, const void *in,
-                        void *out);
-int ccmode_ccm_encrypt(ccccm_ctx *ctx, ccccm_nonce *nonce_ctx, size_t nbytes, const void *in,
-                        void *out);
-int ccmode_ccm_finalize(ccccm_ctx *key, ccccm_nonce *nonce_ctx, void *mac);
-int ccmode_ccm_reset(ccccm_ctx *key, ccccm_nonce *nonce_ctx);
-
-struct _ccmode_ccm_key {
-    const struct ccmode_ecb *ecb;
-    cc_unit u[];
-};
-
-struct _ccmode_ccm_nonce {
-    unsigned char A_i[16];      /* crypto block iv */
-    unsigned char B_i[16];      /* mac block iv */
-    unsigned char MAC[16];      /* crypted mac */
-    unsigned char buf[16];      /* crypt buffer */
-
-    uint32_t mode;         /* mode: IV -> AD -> DATA */
-    uint32_t buflen;       /* length of data in buf */
-    uint32_t b_i_len;      /* length of cbcmac data in B_i */
-
-    size_t nonce_size;
-    size_t mac_size;
-};
-
-/* Use this to statically initialize a ccmode_ccm object for decryption. */
-#define CCMODE_FACTORY_CCM_DECRYPT(ECB_ENCRYPT) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_ccm_key)) + ccn_sizeof_size((ECB_ENCRYPT)->block_size) + ccn_sizeof_size((ECB_ENCRYPT)->size), \
-.nonce_size = ccn_sizeof_size(sizeof(struct _ccmode_ccm_nonce)), \
-.block_size = 1, \
-.init = ccmode_ccm_init, \
-.set_iv = ccmode_ccm_set_iv, \
-.cbcmac = ccmode_ccm_cbcmac, \
-.ccm = ccmode_ccm_decrypt, \
-.finalize = ccmode_ccm_finalize, \
-.reset = ccmode_ccm_reset, \
-.custom = (ECB_ENCRYPT) \
-}
-
-/* Use this to statically initialize a ccmode_ccm object for encryption. */
-#define CCMODE_FACTORY_CCM_ENCRYPT(ECB_ENCRYPT) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_ccm_key)) + ccn_sizeof_size((ECB_ENCRYPT)->block_size) + ccn_sizeof_size((ECB_ENCRYPT)->size), \
-.nonce_size = ccn_sizeof_size(sizeof(struct _ccmode_ccm_nonce)), \
-.block_size = 1, \
-.init = ccmode_ccm_init, \
-.set_iv = ccmode_ccm_set_iv, \
-.cbcmac = ccmode_ccm_cbcmac, \
-.ccm = ccmode_ccm_encrypt, \
-.finalize = ccmode_ccm_finalize, \
-.reset = ccmode_ccm_reset, \
-.custom = (ECB_ENCRYPT) \
-}
 
 /* Use these function to runtime initialize a ccmode_ccm decrypt object (for
  example if it's part of a larger structure). For CCM you always pass a
@@ -433,72 +162,12 @@ void ccmode_factory_ccm_decrypt(struct ccmode_ccm *ccm,
 void ccmode_factory_ccm_encrypt(struct ccmode_ccm *ccm,
                                 const struct ccmode_ecb *ecb_encrypt);
 
-
-int ccmode_ofb_init(const struct ccmode_ofb *ofb, ccofb_ctx *ctx,
-                    size_t rawkey_len, const void *rawkey,
-                    const void *iv);
-int ccmode_ofb_crypt(ccofb_ctx *ctx, size_t nbytes,
-                     const void *in, void *out);
-
-struct _ccmode_ofb_key {
-    const struct ccmode_ecb *ecb;
-    size_t pad_len;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_ofb object. */
-#define CCMODE_FACTORY_OFB_CRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_ofb_key)) + ccn_sizeof_size((ECB)->block_size) + ccn_sizeof_size((ECB)->size), \
-.block_size = 1, \
-.init = ccmode_ofb_init, \
-.ofb = ccmode_ofb_crypt, \
-.custom = (ECB) \
-}
-
 /* Use these function to runtime initialize a ccmode_ofb encrypt object (for
  example if it's part of a larger structure). Normally you would pass a
  ecb encrypt mode implementation of some underlying algorithm as the ecb
  parameter. */
 void ccmode_factory_ofb_crypt(struct ccmode_ofb *ofb,
                               const struct ccmode_ecb *ecb);
-
-int ccmode_omac_decrypt(ccomac_ctx *ctx, size_t nblocks,
-                        const void *tweak, const void *in, void *out);
-int ccmode_omac_encrypt(ccomac_ctx *ctx, size_t nblocks,
-                        const void *tweak, const void *in, void *out);
-
-/* Create a omac key from a omac mode object.  The tweak_len here
- determines how long the tweak is in bytes, for each subsequent call to
- ccmode_omac->omac().
- key must point to at least sizeof(CCMODE_OMAC_KEY(ecb)) bytes of free
- storage. */
-int ccmode_omac_init(const struct ccmode_omac *omac, ccomac_ctx *ctx,
-                     size_t tweak_len, size_t rawkey_len,
-                     const void *rawkey);
-
-struct _ccmode_omac_key {
-    const struct ccmode_ecb *ecb;
-    size_t tweak_len;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_omac object for decryption. */
-#define CCMODE_FACTORY_OMAC_DECRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_omac_key)) + 2 * ccn_sizeof_size((ECB)->size), \
-.block_size = (ECB)->block_size, \
-.init = ccmode_omac_init, \
-.omac = ccmode_omac_decrypt, \
-.custom = (ECB) \
-}
-
-/* Use this to statically initialize a ccmode_omac object for encryption. */
-#define CCMODE_FACTORY_OMAC_ENCRYPT(ECB) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_omac_key)) + 2 * ccn_sizeof_size((ECB)->size), \
-.block_size = (ECB)->block_size, \
-.init = ccmode_omac_init, \
-.omac = ccmode_omac_encrypt, \
-.custom = (ECB) \
-}
 
 /* Use these function to runtime initialize a ccmode_omac decrypt object (for
  example if it's part of a larger structure). Normally you would pass a
@@ -513,62 +182,6 @@ void ccmode_factory_omac_decrypt(struct ccmode_omac *omac,
  parameter. */
 void ccmode_factory_omac_encrypt(struct ccmode_omac *omac,
                                  const struct ccmode_ecb *ecb);
-
-
-/* Function prototypes used by the macros below, do not call directly. */
-int ccmode_xts_init(const struct ccmode_xts *xts, ccxts_ctx *ctx,
-                    size_t key_nbytes, const void *data_key,
-                    const void *tweak_key);
-void ccmode_xts_key_sched(const struct ccmode_xts *xts, ccxts_ctx *ctx,
-                          size_t key_nbytes, const void *data_key,
-                          const void *tweak_key);
-void *ccmode_xts_crypt(const ccxts_ctx *ctx, ccxts_tweak *tweak,
-                       size_t nblocks, const void *in, void *out);
-int ccmode_xts_set_tweak(const ccxts_ctx *ctx, ccxts_tweak *tweak,
-                         const void *iv);
-
-
-struct _ccmode_xts_key {
-    const struct ccmode_ecb *ecb;
-    const struct ccmode_ecb *ecb_encrypt;
-    cc_unit u[];
-};
-
-struct _ccmode_xts_tweak {
-    // FIPS requires that for XTS that no more that 2^20 AES blocks may be processed for any given
-    // Key, Tweak Key, and tweak combination
-    // the bytes_processed field in the context will accumuate the number of blocks processed and
-    // will fail the encrypt/decrypt if the size is violated.  This counter will be reset to 0
-    // when set_tweak is called.
-    size_t  blocks_processed;
-    cc_unit u[];
-};
-
-/* Use this to statically initialize a ccmode_xts object for decryption. */
-#define CCMODE_FACTORY_XTS_DECRYPT(ECB, ECB_ENCRYPT) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_xts_key)) + 2 * ccn_sizeof_size((ECB)->size), \
-.tweak_size = ccn_sizeof_size(sizeof(struct _ccmode_xts_tweak)) + ccn_sizeof_size(ecb->block_size), \
-.block_size = ecb->block_size, \
-.init = ccmode_xts_init, \
-.key_sched = ccmode_xts_key_sched, \
-.set_tweak = ccmode_xts_set_tweak, \
-.xts = ccmode_xts_crypt, \
-.custom = (ECB), \
-.custom1 = (ECB_ENCRYPT) \
-}
-
-/* Use this to statically initialize a ccmode_xts object for encryption. */
-#define CCMODE_FACTORY_XTS_ENCRYPT(ECB, ECB_ENCRYPT) { \
-.size = ccn_sizeof_size(sizeof(struct _ccmode_xts_key)) + 2 * ccn_sizeof_size((ECB)->size), \
-.tweak_size = ccn_sizeof_size(sizeof(struct _ccmode_xts_tweak)) + ccn_sizeof_size(ecb->block_size), \
-.block_size = ecb->block_size, \
-.init = ccmode_xts_init, \
-.key_sched = ccmode_xts_key_sched, \
-.set_tweak = ccmode_xts_set_tweak, \
-.xts = ccmode_xts_crypt, \
-.custom = (ECB), \
-.custom1 = (ECB_ENCRYPT) \
-}
 
 /* Use these function to runtime initialize a ccmode_xts decrypt object (for
  example if it's part of a larger structure). Normally you would pass a

--- a/include/corecrypto/ccmode_siv.h
+++ b/include/corecrypto/ccmode_siv.h
@@ -68,8 +68,7 @@ CC_INLINE size_t ccsiv_plaintext_size(const struct ccmode_siv *mode,
     return ciphertext_size-mode->cbc->block_size;
 }
 
-// In theory, supported key sizes are 32, 48, 64 bytes
-// In practice, we only support key size 32 bytes due to cmac limitation
+// Supported key sizes are 32, 48, 64 bytes
 CC_INLINE int ccsiv_init(const struct ccmode_siv *mode, ccsiv_ctx *ctx,
                           size_t key_byte_len, const uint8_t *key)
 {
@@ -115,7 +114,8 @@ CC_INLINE int ccsiv_one_shot(const struct ccmode_siv *mode,
 {
     int rc;
     ccsiv_ctx_decl(mode->size, ctx);
-    ccsiv_init(mode, ctx, key_len, key);
+    rc=mode->init(mode, ctx, key_len, key);
+    if (rc) {return rc;}
     rc=mode->set_nonce(ctx, nonce_nbytes, nonce);
     if (rc) {return rc;}
     rc=mode->auth(ctx, adata_nbytes, adata);
@@ -125,14 +125,5 @@ CC_INLINE int ccsiv_one_shot(const struct ccmode_siv *mode,
     ccsiv_ctx_clear(mode->size, ctx);
     return rc;
 }
-
-void ccmode_factory_siv_encrypt(struct ccmode_siv *siv,
-                                const struct ccmode_cbc *cbc,
-                                const struct ccmode_ctr *ctr);
-
-void ccmode_factory_siv_decrypt(struct ccmode_siv *siv,
-                                const struct ccmode_cbc *cbc,
-                                const struct ccmode_ctr *ctr);
-
 
 #endif /* _CORECRYPTO_CCMODE_H_ */

--- a/include/corecrypto/ccn.h
+++ b/include/corecrypto/ccn.h
@@ -94,6 +94,8 @@ typedef struct {
 /* Returns the count (n) of a ccn vector that can represent _size_ bytes. */
 #define ccn_nof_size(_size_)  (((_size_) + CCN_UNIT_SIZE - 1) / CCN_UNIT_SIZE)
 
+#define ccn_nof_sizeof(_expr_) ccn_nof_size(sizeof (_expr_))
+
 /* Return the max number of bits a ccn vector of _n_ units can hold. */
 #define ccn_bitsof_n(_n_)  ((_n_) * CCN_UNIT_BITS)
 
@@ -283,7 +285,7 @@ typedef struct {
 #define CCN521_N  ccn_nof(521)
 
 /* Return the number of used units after stripping leading 0 units.  */
-CC_PURE CC_NONNULL2
+CC_PURE CC_NONNULL((2))
 cc_size ccn_n(cc_size n, const cc_unit *s);
 
 /* s >> k -> r return bits shifted out of least significant word in bits [0, n>
@@ -292,28 +294,12 @@ cc_size ccn_n(cc_size n, const cc_unit *s);
  word shifts.  */
 CC_NONNULL((2, 3))
 cc_unit ccn_shift_right(cc_size n, cc_unit *r, const cc_unit *s, size_t k);
-CC_NONNULL((2, 3))
-void ccn_shift_right_multi(cc_size n, cc_unit *r,const cc_unit *s, size_t k);
-
-/* s << k -> r return bits shifted out of most significant word in bits [0, n>
- { N bit, scalar -> N bit } N = n * sizeof(cc_unit) * 8
- the _multi version doesn't return the shifted bits, but does support multiple
- word shifts */
-CC_NONNULL((2, 3))
-cc_unit ccn_shift_left(cc_size n, cc_unit *r, const cc_unit *s, size_t k);
-CC_NONNULL((2, 3))
-void ccn_shift_left_multi(cc_size n, cc_unit *r, const cc_unit *s, size_t k);
 
 /* s == 0 -> return 0 | s > 0 -> return index (starting at 1) of most
  significant bit that is 1.
  { N bit } N = n * sizeof(cc_unit) * 8 */
-CC_NONNULL2
+CC_NONNULL((2))
 size_t ccn_bitlen(cc_size n, const cc_unit *s);
-
-/* Returns the number of bits which are zero before the first one bit
-   counting from least to most significant bit. */
-CC_NONNULL2
-size_t ccn_trailing_zeros(cc_size n, const cc_unit *s);
 
 /* s == 0 -> return true | s != 0 -> return false
  { N bit } N = n * sizeof(cc_unit) * 8 */
@@ -347,9 +333,6 @@ int ccn_cmpn(cc_size ns, const cc_unit *s,
  { N bit, N bit -> N bit } N = n * sizeof(cc_unit) * 8 */
 CC_NONNULL((2, 3, 4))
 cc_unit ccn_sub(cc_size n, cc_unit *r, const cc_unit *s, const cc_unit *t);
-
-/* |s - t| -> r return 1 iff t > s, 0 otherwise */
-cc_unit ccn_abs(cc_size n, cc_unit *r, const cc_unit *s, const cc_unit *t);
 
 /* s - v -> r return 1 iff v > s return 0 otherwise.
  { N bit, sizeof(cc_unit) * 8 bit -> N bit } N = n * sizeof(cc_unit) * 8 */
@@ -388,22 +371,11 @@ cc_unit ccn_addn(cc_size n, cc_unit *r, const cc_unit *s,
 }
 
 
-CC_NONNULL((2, 3, 4))
-void ccn_lcm(cc_size n, cc_unit *r2n, const cc_unit *s, const cc_unit *t);
-
-
 /* s * t -> r_2n                   r_2n must not overlap with s nor t
  { n bit, n bit -> 2 * n bit } n = count * sizeof(cc_unit) * 8
  { N bit, N bit -> 2N bit } N = ccn_bitsof(n) */
 CC_NONNULL((2, 3, 4))
 void ccn_mul(cc_size n, cc_unit *r_2n, const cc_unit *s, const cc_unit *t);
-
-/* s * t -> r_2n                   r_2n must not overlap with s nor t
- { n bit, n bit -> 2 * n bit } n = count * sizeof(cc_unit) * 8
- { N bit, N bit -> 2N bit } N = ccn_bitsof(n) 
- Provide a workspace for potential speedup */
-CC_NONNULL((2, 3, 4, 5))
-void ccn_mul_ws(cc_size count, cc_unit *r, const cc_unit *s, const cc_unit *t, cc_ws_t ws);
 
 /* s[0..n) * v -> r[0..n)+return value
  { N bit, sizeof(cc_unit) * 8 bit -> N + sizeof(cc_unit) * 8 bit } N = n * sizeof(cc_unit) * 8 */
@@ -422,28 +394,18 @@ CC_NONNULL((2, 3, 4))
 void ccn_mod(cc_size n, cc_unit *r, const cc_unit *a_2n, const cc_unit *d);
 #endif
 
-/* r = gcd(s, t).
-   N bit, N bit -> N bit */
-CC_NONNULL((2, 3, 4))
-void ccn_gcd(cc_size n, cc_unit *r, const cc_unit *s, const cc_unit *t);
-
-/* r = gcd(s, t).
- N bit, N bit -> O bit */
-CC_NONNULL((2, 4, 6))
-void ccn_gcdn(cc_size rn, cc_unit *r, cc_size sn, const cc_unit *s, cc_size tn, const cc_unit *t);
-
 /* r = (data, len) treated as a big endian byte array, return -1 if data
  doesn't fit in r, return 0 otherwise. */
 CC_NONNULL((2, 4))
 int ccn_read_uint(cc_size n, cc_unit *r, size_t data_size, const uint8_t *data);
 
 /* r = (data, len) treated as a big endian byte array, return -1 if data
- doesn't fit in r, return 0 otherwise. 
+ doesn't fit in r, return 0 otherwise.
  ccn_read_uint strips leading zeroes and doesn't care about sign. */
 #define ccn_read_int(n, r, data_size, data) ccn_read_uint(n, r, data_size, data)
 
 /* Return actual size in bytes needed to serialize s. */
-CC_PURE CC_NONNULL2
+CC_PURE CC_NONNULL((2))
 size_t ccn_write_uint_size(cc_size n, const cc_unit *s);
 
 /* Serialize s, to out.
@@ -473,9 +435,9 @@ cc_size ccn_write_uint_padded(cc_size n, const cc_unit* s, size_t out_size, uint
 }
 
 
-/*  Return actual size in bytes needed to serialize s as int 
+/*  Return actual size in bytes needed to serialize s as int
     (adding leading zero if high bit is set). */
-CC_PURE CC_NONNULL2
+CC_PURE CC_NONNULL((2))
 size_t ccn_write_int_size(cc_size n, const cc_unit *s);
 
 /*  Serialize s, to out.
@@ -491,55 +453,25 @@ size_t ccn_write_int_size(cc_size n, const cc_unit *s);
 CC_NONNULL((2, 4))
 void ccn_write_int(cc_size n, const cc_unit *s, size_t out_size, void *out);
 
-#if CCN_DEDICATED_SQR
-
-/* s^2 -> r
- { n bit -> 2 * n bit } */
-CC_NONNULL((2, 3))
-void ccn_sqr(cc_size n, cc_unit *r, const cc_unit *s);
-
-/* s^2 -> r
- { n bit -> 2 * n bit } */
-CC_NONNULL((2, 3, 4))
-void ccn_sqr_ws(cc_size n, cc_unit *r, const cc_unit *s, cc_ws_t ws);
-
-#else
-
-/* s^2 -> r
- { n bit -> 2 * n bit } */
-CC_INLINE CC_NONNULL((2, 3))
-void ccn_sqr(cc_size n, cc_unit *r, const cc_unit *s) {
-    ccn_mul(n, r, s, s);
-}
-
-/* s^2 -> r
- { n bit -> 2 * n bit } */
-CC_INLINE CC_NONNULL((2, 3, 4))
-void ccn_sqr_ws(cc_size n, cc_unit *r, const cc_unit *s, cc_ws_t ws) {
-    ccn_mul_ws(n, r, s, s, ws);
-}
-
-#endif
-
 /* s -> r
  { n bit -> n bit } */
 CC_NONNULL((2, 3))
 void ccn_set(cc_size n, cc_unit *r, const cc_unit *s);
 
-CC_INLINE CC_NONNULL2
+CC_INLINE CC_NONNULL((2))
 void ccn_zero(cc_size n, cc_unit *r) {
     cc_zero(ccn_sizeof_n(n),r);
 }
 
-CC_INLINE CC_NONNULL2
+CC_INLINE CC_NONNULL((2))
 void ccn_clear(cc_size n, cc_unit *r) {
     cc_clear(ccn_sizeof_n(n),r);
 }
 
-CC_NONNULL2
+CC_NONNULL((2))
 void ccn_zero_multi(cc_size n, cc_unit *r, ...);
 
-CC_INLINE CC_NONNULL2
+CC_INLINE CC_NONNULL((2))
 void ccn_seti(cc_size n, cc_unit *r, cc_unit v) {
     /* assert(n > 0); */
     r[0] = v;
@@ -589,7 +521,7 @@ void ccn_setn(cc_size n, cc_unit *r, const cc_size s_size, const cc_unit *s) {
 #endif
 
 /* Swap units in r in place from cc_unit vector byte order to big endian byte order (or back). */
-CC_INLINE CC_NONNULL2
+CC_INLINE CC_NONNULL((2))
 void ccn_swap(cc_size n, cc_unit *r) {
     cc_unit *e;
     for (e = r + n - 1; r < e; ++r, --e) {
@@ -609,9 +541,9 @@ void ccn_xor(cc_size n, cc_unit *r, const cc_unit *s, const cc_unit *t) {
 }
 
 /* Debugging */
-CC_NONNULL2
+CC_NONNULL((2))
 void ccn_print(cc_size n, const cc_unit *s);
-CC_NONNULL3
+CC_NONNULL((3))
 void ccn_lprint(cc_size n, const char *label, const cc_unit *s);
 
 /* Forward declaration so we don't depend on ccrng.h. */
@@ -631,38 +563,10 @@ int ccn_random(cc_size n, cc_unit *r, struct ccrng_state *rng) {
 CC_NONNULL((2, 3))
 int ccn_random_bits(cc_size nbits, cc_unit *r, struct ccrng_state *rng);
 
-/*!
- @brief ccn_make_recip(cc_size nd, cc_unit *recip, const cc_unit *d) computes the reciprocal of d: recip = 2^2b/d where b=bitlen(d)
-
- @param nd      length of array d
- @param recip   returned reciprocal of size nd+1
- @param d       input number d
-*/
-CC_NONNULL((2, 3))
-void ccn_make_recip(cc_size nd, cc_unit *recip, const cc_unit *d);
-
 CC_NONNULL((6, 8))
 int ccn_div_euclid(cc_size nq, cc_unit *q, cc_size nr, cc_unit *r, cc_size na, const cc_unit *a, cc_size nd, const cc_unit *d);
 
 #define ccn_div(nq, q, na, a, nd, d) ccn_div_euclid(nq, q, 0, NULL, na, a, nd, d)
 #define ccn_mod(nr, r, na, a, nd, d) ccn_div_euclid(0 , NULL, nr, r, na, a, nd, d)
-
-/*!
- @brief ccn_div_use_recip(nq, q, nr, r, na, a, nd, d) comutes q=a/d and r=a%d
- @discussion q and rcan be NULL. Reads na from a and nd from d. Writes nq in q and nr in r. nq and nr must be large enough to accomodate results, otherwise error is retuned. Execution time depends on the size of a. Computation is perfomed on of fixedsize and the leadig zeros of a of q are are also used in the computation.
- @param nq length of array q that hold the quotients. The maximum length of quotient is the actual length of dividend a
- @param q  returned quotient. If nq is larger than needed, it is filled with leading zeros. If it is smaller, error is returned. q can be set to NULL, if not needed.
- @param nr length of array r that hold the remainder. The maximum length of remainder is the actual length of divisor d
- @param r  returned remainder. If nr is larger than needed, it is filled with leading zeros. Ifi is smaller error is returned. r can be set to NULL if not required.
- @param na length of dividend. Dividend may have leading zeros.
- @param a  input Dividend
- @param nd length of input divisor. Divisor may have leading zeros.
- @param d  input Divisor
- @param recip_d The reciprocal of d, of length nd+1.
-
- @return  returns 0 if successful, negative of error.
- */
-CC_NONNULL((6, 8, 9))
-int ccn_div_use_recip(cc_size nq, cc_unit *q, cc_size nr, cc_unit *r, cc_size na, const cc_unit *a, cc_size nd, const cc_unit *d, const cc_unit *recip_d);
 
 #endif /* _CORECRYPTO_CCN_H_ */

--- a/include/corecrypto/ccrc4.h
+++ b/include/corecrypto/ccrc4.h
@@ -26,19 +26,8 @@ struct ccrc4_info {
     void (*crypt)(ccrc4_ctx *ctx, size_t nbytes, const void *in, void *out);
 };
 
-
 const struct ccrc4_info *ccrc4(void);
 
 extern const struct ccrc4_info ccrc4_eay;
-
-struct ccrc4_vector {
-    size_t keylen;
-    const void *key;
-    size_t datalen;
-    const void *pt;
-    const void *ct;
-};
-
-int ccrc4_test(const struct ccrc4_info *rc4, const struct ccrc4_vector *v);
 
 #endif /* _CORECRYPTO_CCRC4_H_ */

--- a/include/corecrypto/ccrng.h
+++ b/include/corecrypto/ccrng.h
@@ -11,33 +11,38 @@
 #ifndef _CORECRYPTO_CCRNG_H_
 #define _CORECRYPTO_CCRNG_H_
 
-#include <stdint.h>
-
 #include <corecrypto/cc.h>
-
-#define CC_ERR_DEVICE                   -100
-#define CC_ERR_INTERUPTS                -101
-#define CC_ERR_CRYPTO_CONFIG            -102
-#define CC_ERR_PERMS                    -103
-#define CC_ERR_PARAMETER                -104
-#define CC_ERR_MEMORY                   -105
-#define CC_ERR_FILEDESC                 -106
-#define CC_ERR_OUT_OF_ENTROPY           -107
-#define CC_ERR_INTERNAL                 -108
-#define CC_ERR_ATFORK                   -109
-#define CC_ERR_OVERFLOW                 -110
 
 #define CCRNG_STATE_COMMON                                                          \
     int (*generate)(struct ccrng_state *rng, size_t outlen, void *out);
 
-/* Get a pointer to a ccrng has never been simpler! Just call this */
-struct ccrng_state *ccrng(int *error);
-
-/* default state structure - do not instantiate, instead use the specific one you need */
+/* default state structure. Do not instantiate, ccrng() returns a reference to this structure */
 struct ccrng_state {
     CCRNG_STATE_COMMON
 };
 
-#define ccrng_generate(ctx, outlen, out) ((ctx)->generate((ctx), (outlen), (out)))
+/*!
+ @function   ccrng
+ @abstract   initializes a AES-CTR mode cryptographic random number generator and returns the statically alocated rng object. 
+             Getting a pointer to a ccrng has never been simpler! 
+             Call this function, get an rng object and then pass the object to ccrng_generate() to generate randoms.
+             ccrng() may be called more than once. It returns pointer to the same object on all calls.
+
+ @result  a cryptographically secure random number generator or NULL if fails
+ 
+ @discussion 
+ - It is significantly faster than using the system /dev/random
+ - FIPS Compliant: NIST SP800-80A + FIPS 140-2
+ - Seeded from the system entropy.
+ - Provides at least 128bit security if the system provide 2bit of entropy / byte.
+ - Entropy accumulation
+ - Backtracing resistance
+ - Prediction break with frequent (asynchronous) reseed
+ */
+
+struct ccrng_state *ccrng(int *error);
+
+//call this macro with the rng argument set to output of the call to the ccrng() function
+#define ccrng_generate(rng, outlen, out) ((rng)->generate((struct ccrng_state *)(rng), (outlen), (out)))
 
 #endif /* _CORECRYPTO_CCRNG_H_ */

--- a/include/corecrypto/ccrsa.h
+++ b/include/corecrypto/ccrsa.h
@@ -21,17 +21,6 @@
 // This limit is relaxed to accommodate potential third-party consumers
 #define CCRSA_KEYGEN_MAX_NBITS 8192
 
-// Program error: buffer too small or encrypted message is too small
-#define CCRSA_INVALID_INPUT        -1
-// Invalid crypto configuration: Hash length versus RSA key size
-#define CCRSA_INVALID_CONFIG       -2
-// The data is invalid (we won't say more for security
-#define CCRSA_DECRYPTION_ERROR     -3
-
-#define CCRSA_ENCODING_ERROR       -4
-#define CCRSA_DECODING_ERROR       -5
-#define CCRSA_SIGNATURE_GEN_ERROR  -6
-
 struct ccrsa_full_ctx {
     __CCZP_ELEMENTS_DEFINITIONS(pb_)
 } CC_ALIGNED(CCN_UNIT_SIZE);
@@ -44,32 +33,9 @@ struct ccrsa_priv_ctx {
     __CCZP_ELEMENTS_DEFINITIONS(pv_)
 } CC_ALIGNED(CCN_UNIT_SIZE);
 
-
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-    typedef union {
-        cczp_t zp;
-        struct ccrsa_pub_ctx* pub;
-        struct ccrsa_full_ctx *full;
-    } ccrsa_full_ctx_t __attribute__((transparent_union));
-    typedef struct ccrsa_full_ctx ccrsa_full_ctx;
-    typedef struct ccrsa_priv_ctx ccrsa_priv_ctx;
-
-    typedef union {
-        cczp_t zp;
-        ccrsa_priv_ctx *priv;
-    } ccrsa_priv_ctx_t __attribute__((transparent_union));
-
-
-typedef ccrsa_full_ctx_t ccrsa_pub_ctx_t;
-typedef struct ccrsa_pub_ctx ccrsa_pub_ctx;
-
-#else
-    typedef struct ccrsa_full_ctx* ccrsa_full_ctx_t;
-    typedef struct ccrsa_pub_ctx* ccrsa_pub_ctx_t;
-    typedef struct ccrsa_priv_ctx* ccrsa_priv_ctx_t;
-#endif
-
-
+typedef struct ccrsa_full_ctx* ccrsa_full_ctx_t;
+typedef struct ccrsa_pub_ctx* ccrsa_pub_ctx_t;
+typedef struct ccrsa_priv_ctx* ccrsa_priv_ctx_t;
 
 /*
  public key cczp      d=e^-1 mod phi(m) priv key cczp             priv key cczq             dp, dq, qinv
@@ -90,7 +56,7 @@ typedef struct ccrsa_pub_ctx ccrsa_pub_ctx;
 
 /* Declare a fully scheduled rsa key.  Size is the size in bytes each ccn in
    the key.  For example to declare (on the stack or in a struct) a 1021 bit
-   rsa public key named foo use ccrsa_pub_ctx_decl(ccn_sizeof(1021), foo). 
+   rsa public key named foo use ccrsa_pub_ctx_decl(ccn_sizeof(1021), foo).
  */
 #define ccrsa_full_ctx_decl(_size_, _name_)   cc_ctx_decl(struct ccrsa_full_ctx, ccrsa_full_ctx_size(_size_), _name_)
 #define ccrsa_full_ctx_clear(_size_, _name_)  cc_clear(ccrsa_full_ctx_size(_size_), _name_)
@@ -101,19 +67,9 @@ typedef struct ccrsa_pub_ctx ccrsa_pub_ctx;
 // The offsets are computed using pb_ccn. If any object other than ccrsa_full_ctx_t
 // or ccrsa_pub_ctx_t is passed to the macros, compiler error is generated.
 
-
-
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-//#define ccrsa_ctx_zm(_ctx_)        (((ccrsa_pub_ctx_t)(_ctx_)).zp)
-
-    CC_CONST CC_INLINE cczp_t ccrsa_ctx_zm(ccrsa_full_ctx_t _ctx_) { return ((cczp_t)(struct cczp *)((_ctx_).full)); }
-    CC_CONST CC_INLINE cc_unit  *ccrsa_ctx_m(ccrsa_full_ctx_t _ctx_){ return        ((_ctx_).full->pb_ccn);}
-    #define ccrsa_ctx_n(_ctx_)         (ccrsa_ctx_zm(_ctx_).zp->n)
-#else
-    #define ccrsa_ctx_zm(_ctx_)        ((cczp_t)(_ctx_))
-    #define ccrsa_ctx_n(_ctx_)         (ccrsa_ctx_zm(_ctx_)->n)
-    #define ccrsa_ctx_m(_ctx_)         ((_ctx_)->pb_ccn)
-#endif
+#define ccrsa_ctx_zm(_ctx_)        ((cczp_t)(_ctx_))
+#define ccrsa_ctx_n(_ctx_)         (ccrsa_ctx_zm(_ctx_)->n)
+#define ccrsa_ctx_m(_ctx_)         ((_ctx_)->pb_ccn)
 
 #define ccrsa_ctx_e(_ctx_)         (ccrsa_ctx_m(_ctx_) + 2 * ccrsa_ctx_n(_ctx_) + 1)
 #define ccrsa_ctx_d(_ctx_)         (ccrsa_ctx_m(_ctx_) + 3 * ccrsa_ctx_n(_ctx_) + 1)
@@ -121,36 +77,13 @@ typedef struct ccrsa_pub_ctx ccrsa_pub_ctx;
 // accessors to ccrsa private key fields
 // The offsets are computed using pv_ccn. If any object other than ccrsa_priv_ctx_t
 // is passed to the macros, compiler error is generated.
-#if CORECRYPTO_USE_TRANSPARENT_UNION
-
-/* rvalue accessors to ccec_key fields. */
-CC_CONST CC_INLINE
-ccrsa_priv_ctx_t ccrsa_get_private_ctx_ptr(ccrsa_full_ctx_t fk) {
-    cc_unit *p = (cc_unit *)fk.full;
-    cc_size p_size = ccrsa_ctx_n(fk);
-    p += ccn_nof_size(ccrsa_pub_ctx_size(ccn_sizeof_n(p_size))) + p_size;
-    ccrsa_priv_ctx *priv = (ccrsa_priv_ctx *)p;
-    return (ccrsa_priv_ctx_t)priv;
-}
-
-CC_CONST CC_INLINE
-ccrsa_pub_ctx_t ccrsa_ctx_public(ccrsa_full_ctx_t fk) {
-    return (ccrsa_pub_ctx_t) fk.full;
-}
-
-#define ccrsa_ctx_private_zp(FK)   ((ccrsa_get_private_ctx_ptr(FK)).zp)
-#define ccrsa_ctx_private_zq(FK)   ((cczp_t)((ccrsa_get_private_ctx_ptr(FK)).zp.zp->ccn + 2 * ccrsa_ctx_private_zp(FK).zp->n + 1))
-#define ccrsa_ctx_private_dp(FK)   ((ccrsa_get_private_ctx_ptr(FK)).zp.zp->ccn + 4 * ccrsa_ctx_private_zp(FK).zp->n + 2 + ccn_nof_size(sizeof(struct cczp)))
-#define ccrsa_ctx_private_dq(FK)   ((ccrsa_get_private_ctx_ptr(FK)).zp.zp->ccn + 5 * ccrsa_ctx_private_zp(FK).zp->n + 2 + ccn_nof_size(sizeof(struct cczp)))
-#define ccrsa_ctx_private_qinv(FK) ((ccrsa_get_private_ctx_ptr(FK)).zp.zp->ccn + 6 * ccrsa_ctx_private_zp(FK).zp->n + 2 + ccn_nof_size(sizeof(struct cczp)))
-
-#else
 #define ccrsa_ctx_private_zp(FK)   ((cczp_t)ccrsa_get_private_ctx_ptr(FK))
 #define ccrsa_ctx_private_zq(FK)   ((cczp_t)((ccrsa_get_private_ctx_ptr(FK))->pv_ccn + 2 * ccrsa_ctx_private_zp(FK)->n + 1))
 #define ccrsa_ctx_private_dp(FK)   ((ccrsa_get_private_ctx_ptr(FK))->pv_ccn + 4 * ccrsa_ctx_private_zp(FK)->n + 2 + ccn_nof_size(sizeof(struct cczp)))
 #define ccrsa_ctx_private_dq(FK)   ((ccrsa_get_private_ctx_ptr(FK))->pv_ccn + 5 * ccrsa_ctx_private_zp(FK)->n + 2 + ccn_nof_size(sizeof(struct cczp)))
 #define ccrsa_ctx_private_qinv(FK) ((ccrsa_get_private_ctx_ptr(FK))->pv_ccn + 6 * ccrsa_ctx_private_zp(FK)->n + 2 + ccn_nof_size(sizeof(struct cczp)))
 
+/* rvalue accessors to ccec_key fields. */
 CC_CONST CC_INLINE
 ccrsa_priv_ctx_t ccrsa_get_private_ctx_ptr(ccrsa_full_ctx_t fk) {
     ccrsa_priv_ctx_t priv = (ccrsa_priv_ctx_t)(ccrsa_ctx_d(fk)+ccrsa_ctx_n(fk));
@@ -168,8 +101,6 @@ ccrsa_pub_ctx_t ccrsa_ctx_public(ccrsa_full_ctx_t fk) {
     return (ccrsa_pub_ctx_t) fk;
 }
 
-#endif
-
 /* Return exact key bit size */
 static inline size_t
 ccrsa_pubkeylength(ccrsa_pub_ctx_t pubk) {
@@ -181,13 +112,13 @@ ccrsa_pubkeylength(ccrsa_pub_ctx_t pubk) {
 #define CCRSA_PKCS1_PAD_ENCRYPT  2
 
 /* Initialize key based on modulus and e as cc_unit.  key->zp.n must already be set. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-void ccrsa_init_pub(ccrsa_pub_ctx_t key, const cc_unit *modulus,
+CC_NONNULL((1, 2, 3))
+int ccrsa_init_pub(ccrsa_pub_ctx_t key, const cc_unit *modulus,
                     const cc_unit *e);
 
 /* Initialize key based on modulus and e as big endian byte array
     key->zp.n must already be set. */
-CC_NONNULL_TU((1)) CC_NONNULL((3 ,5))
+CC_NONNULL((1, 3, 5))
 int ccrsa_make_pub(ccrsa_pub_ctx_t pubk,
                               size_t exp_nbytes, const uint8_t *exp,
                               size_t mod_nbytes, const uint8_t *mod);
@@ -196,7 +127,7 @@ int ccrsa_make_pub(ccrsa_pub_ctx_t pubk,
    the result in out. Both in and out should be cc_unit aligned and
    ccrsa_key_n(key) units long. Clients should use ccn_read_uint() to
    convert bytes to a cc_unit to use for this API.*/
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
+CC_NONNULL((1, 2, 3))
 int ccrsa_pub_crypt(ccrsa_pub_ctx_t key, cc_unit *out, const cc_unit *in);
 
 /* Generate an nbit rsa key pair in key, which should be allocated using
@@ -204,19 +135,19 @@ int ccrsa_pub_crypt(ccrsa_pub_ctx_t key, cc_unit *out, const cc_unit *in);
    byte array exponent e of length e_size is used as the exponent. It's an
    error to call this function with an exponent larger than nbits. rng
    must be a pointer to an initialized struct ccrng_state. */
-CC_NONNULL_TU((2)) CC_NONNULL((4, 5))
+CC_NONNULL((2, 4, 5))
 int ccrsa_generate_key(size_t nbits, ccrsa_full_ctx_t rsa_ctx,
                        size_t e_size, const void *e, struct ccrng_state *rng) CC_WARN_RESULT;
 
 /* Generate RSA key in conformance with FIPS186-4 standard */
-CC_NONNULL_TU((2)) CC_NONNULL((4, 5, 6))
+CC_NONNULL((2, 4, 5, 6))
 int
 ccrsa_generate_fips186_key(size_t nbits, ccrsa_full_ctx_t fk,
                            size_t e_size, const void *eBytes,
                            struct ccrng_state *rng1, struct ccrng_state *rng2) CC_WARN_RESULT;
 
 /* Construct RSA key from fix input in conformance with FIPS186-4 standard */
-CC_NONNULL_TU((16)) CC_NONNULL((3, 5, 7, 9, 11, 13, 15))
+CC_NONNULL((3, 5, 7, 9, 11, 13, 15, 16))
 int
 ccrsa_make_fips186_key(size_t nbits,
                        const cc_size e_n, const cc_unit *e,
@@ -262,14 +193,14 @@ ccrsa_make_fips186_key(size_t nbits,
  * @param   sigSize           The length of generated signature in bytes, which equals the size of the RSA modulus.
  * @return                   0:ok, non-zero:error
  */
-CC_NONNULL((2,3,5,7,8,9))
+CC_NONNULL((2, 3, 5, 7, 8, 9))
 int ccrsa_sign_pss(ccrsa_full_ctx_t key,
                    const struct ccdigest_info* hashAlgorithm, const struct ccdigest_info* MgfHashAlgorithm,
                    size_t saltSize, struct ccrng_state *rng,
                    size_t hSize, const uint8_t *mHash,
                    size_t *sigSize, uint8_t *sig);
 
-CC_NONNULL((2,3,5,7,9))
+CC_NONNULL((2, 3, 5, 7, 9))
 int ccrsa_verify_pss(ccrsa_pub_ctx_t key,
                      const struct ccdigest_info* di, const struct ccdigest_info* MgfDi,
                      size_t digestSize, const uint8_t *digest,
@@ -290,37 +221,38 @@ int ccrsa_verify_pss(ccrsa_pub_ctx_t key,
                         for the output signature
 
  @result     0 iff successful.
- 
+
   @discussion Null OID is a special case, required to support RFC 4346 where the padding
  is based on SHA1+MD5. In general it is not recommended to use a NULL OID,
  except when strictly required for interoperability
 
  */
-CC_NONNULL_TU((1)) CC_NONNULL((4, 5, 6))
+CC_NONNULL((1, 4, 5, 6))
 int ccrsa_sign_pkcs1v15(ccrsa_full_ctx_t key, const uint8_t *oid,
                         size_t digest_len, const uint8_t *digest,
                         size_t *sig_len, uint8_t *sig);
 
 
 /*!
- @function   ccrsa_sign_pkcs1v15
- @abstract   RSA signature with PKCS#1 v1.5 format per PKCS#1 v2.2
+  @function   ccrsa_verify_pkcs1v15
+  @abstract   RSA signature with PKCS#1 v1.5 format per PKCS#1 v2.2
 
- @param      key        Public key
- @param      oid        OID describing the type of digest passed in
- @param      digest_len Byte length of the digest
- @param      digest     Byte array of digest_len bytes containing the digest
- @param      sig_len    Number of byte of the signature sig.
- @param      sig        Pointer to the signature buffer of sig_len
- @param      valid      Output boolean, true if the signature is valid.
+  @param      key        Public key
+  @param      oid        OID describing the type of digest passed in
+  @param      digest_len Byte length of the digest
+  @param      digest     Byte array of digest_len bytes containing the digest
+  @param      sig_len    Number of byte of the signature sig.
+  @param      sig        Pointer to the signature buffer of sig_len
+  @param      valid      Output boolean, true if the signature is valid.
 
- @result     0 iff successful.
- 
-  @discussion Null OID is a special case, required to support RFC 4346 where the padding
- is based on SHA1+MD5. In general it is not recommended to use a NULL OID, 
- except when strictly required for interoperability
- */
-CC_NONNULL_TU((1)) CC_NONNULL((4, 6, 7))
+  @result     0 iff successful.
+
+  @discussion Null OID is a special case, required to support RFC 4346
+  where the padding is based on SHA1+MD5. In general it is not
+  recommended to use a NULL OID, except when strictly required for
+  interoperability.
+*/
+CC_NONNULL((1, 4, 6, 7))
 int ccrsa_verify_pkcs1v15(ccrsa_pub_ctx_t key, const uint8_t *oid,
                           size_t digest_len, const uint8_t *digest,
                           size_t sig_len, const uint8_t *sig,
@@ -329,80 +261,80 @@ int ccrsa_verify_pkcs1v15(ccrsa_pub_ctx_t key, const uint8_t *oid,
 /*!
  @function   ccder_encode_rsa_pub_size
  @abstract   Calculate size of public key export format data package.
- 
+
  @param      key        Public key
- 
+
  @result     Returns size required for encoding.
  */
 
-CC_NONNULL_TU((1))
+CC_NONNULL((1))
 size_t ccder_encode_rsa_pub_size(const ccrsa_pub_ctx_t key);
 
 /*!
  @function   ccrsa_export_priv_pkcs1
  @abstract   Export a public key.
- 
+
  @param      key        Public key
  @param      der        Beginning of output DER buffer
  @param      der_end    End of output DER buffer
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((2)) CC_NONNULL((3))
+CC_NONNULL((1, 2, 3))
 uint8_t *ccder_encode_rsa_pub(const ccrsa_pub_ctx_t key, uint8_t *der, uint8_t *der_end);
 
 
 /*!
  @function   ccder_encode_rsa_priv_size
  @abstract   Calculate size of full key exported in PKCS#1 format.
- 
+
  @param      key        Full key
- 
+
  @result     Returns size required for encoding.
  */
 
-CC_NONNULL_TU((1))
+CC_NONNULL((1))
 size_t ccder_encode_rsa_priv_size(const ccrsa_full_ctx_t key);
 
 /*!
  @function   ccder_encode_rsa_priv
  @abstract   Export a full key in PKCS#1 format.
- 
+
  @param      key        Full key
  @param      der        Beginning of output DER buffer
  @param      der_end    End of output DER buffer
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((2)) CC_NONNULL((3))
+CC_NONNULL((1, 2, 3))
 uint8_t *ccder_encode_rsa_priv(const ccrsa_full_ctx_t key, const uint8_t *der, uint8_t *der_end);
 
 /*!
  @function   ccder_decode_rsa_pub_n
  @abstract   Calculate "n" for a public key imported from a data package.
         PKCS #1 format
- 
+
  @param      der        Beginning of input DER buffer
  @param      der_end    End of input DER buffer
- 
+
  @result the "n" of the RSA key that would result from the import.  This can be used
  to declare the key itself.
  */
 
-CC_NONNULL((1)) CC_NONNULL((2))
+CC_NONNULL((1, 2))
 cc_size ccder_decode_rsa_pub_n(const uint8_t *der, const uint8_t *der_end);
 
 /*!
  @function   ccder_decode_rsa_pub
  @abstract   Import a public RSA key from a package in public key format.
         PKCS #1 format
- 
+
  @param      key          Public key (n must be set)
  @param      der        Beginning of input DER buffer
  @param      der_end    End of input DER buffer
- 
+
  @result     Key is initialized using the data in the public key message.
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((2)) CC_NONNULL((3))
+CC_NONNULL((1, 2, 3))
 const uint8_t *ccder_decode_rsa_pub(const ccrsa_pub_ctx_t key, const uint8_t *der, const uint8_t *der_end);
 
 /*!
@@ -416,7 +348,7 @@ const uint8_t *ccder_decode_rsa_pub(const ccrsa_pub_ctx_t key, const uint8_t *de
  to declare the key itself.
  */
 
-CC_NONNULL((1)) CC_NONNULL((2))
+CC_NONNULL((1, 2))
 cc_size ccder_decode_rsa_pub_x509_n(const uint8_t *der, const uint8_t *der_end);
 
 /*!
@@ -430,48 +362,48 @@ cc_size ccder_decode_rsa_pub_x509_n(const uint8_t *der, const uint8_t *der_end);
  @result     Key is initialized using the data in the public key message.
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((2)) CC_NONNULL((3))
+CC_NONNULL((1, 2, 3))
 const uint8_t *ccder_decode_rsa_pub_x509(const ccrsa_pub_ctx_t key, const uint8_t *der, const uint8_t *der_end);
 
 
 /*!
  @function   ccder_decode_rsa_priv_n
  @abstract   Calculate "n" for a private key imported from a data package.
- 
+
  @param      der        Beginning of input DER buffer
  @param      der_end    End of input DER buffer
- 
+
  @result the "n" of the RSA key that would result from the import.  This can be used
  to declare the key itself.
  */
 
-CC_NONNULL((1)) CC_NONNULL((2))
+CC_NONNULL((1, 2))
 cc_size ccder_decode_rsa_priv_n(const uint8_t *der, const uint8_t *der_end);
 
 /*!
  @function   ccder_decode_rsa_priv
  @abstract   Import a private RSA key from a package in PKCS#1 format.
- 
+
  @param      key          Full key (n must be set)
  @param      der        Beginning of input DER buffer
  @param      der_end    End of input DER buffer
- 
+
  @result     Key is initialized using the data in the public key message.
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((2)) CC_NONNULL((3))
+CC_NONNULL((1, 2, 3))
 const uint8_t *ccder_decode_rsa_priv(const ccrsa_full_ctx_t key, const uint8_t *der, const uint8_t *der_end);
 
 /*!
  @function   ccrsa_export_pub_size
  @abstract   Calculate size of public key exported data package.
- 
+
  @param      key        Public key
- 
+
  @result     Returns size required for encoding.
  */
 
-CC_CONST CC_INLINE CC_NONNULL_TU((1))
+CC_CONST CC_INLINE CC_NONNULL((1))
 size_t ccrsa_export_pub_size(const ccrsa_pub_ctx_t key) {
     return ccder_encode_rsa_pub_size(key);
 }
@@ -479,21 +411,21 @@ size_t ccrsa_export_pub_size(const ccrsa_pub_ctx_t key) {
 /*!
  @function   ccrsa_export_pub
  @abstract   Export a public key in public key format.
- 
+
  @param      key        Public key
  @param      out_len    Allocated size
  @param      out        Output buffer
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((3))
+CC_NONNULL((1, 3))
 int ccrsa_export_pub(const ccrsa_pub_ctx_t key, size_t out_len, uint8_t *out);
 /*!
  @function   ccrsa_import_pub_n
  @abstract   Calculate "n" for a public key imported from a data package.
- 
+
  @param      inlen        Length of public key package data
  @param      der          pointer to public key package data
- 
+
  @result the "n" of the RSA key that would result from the import.  This can be used
  to declare the key itself.
  */
@@ -510,27 +442,27 @@ cc_size ccrsa_import_pub_n(size_t inlen, const uint8_t *der) {
 /*!
  @function   ccrsa_import_pub
  @abstract   Import a public RSA key from a package in public key format.
- 
+
  @param      key          Public key (n must be set)
  @param      inlen        Length of public key package data
  @param      der           pointer to public key package data
- 
+
  @result     Key is initialized using the data in the public key message.
  */
 
-CC_NONNULL_TU((1)) CC_NONNULL((3))
+CC_NONNULL((1, 3))
 int ccrsa_import_pub(ccrsa_pub_ctx_t key, size_t inlen, const uint8_t *der);
 
 /*!
  @function   ccrsa_export_priv_size
  @abstract   Calculate size of full key exported in PKCS#1 format.
- 
+
  @param      key        Full key
- 
+
  @result     Returns size required for encoding.
  */
 
-CC_CONST CC_INLINE CC_NONNULL_TU((1))
+CC_CONST CC_INLINE CC_NONNULL((1))
 size_t ccrsa_export_priv_size(const ccrsa_full_ctx_t key) {
     return ccder_encode_rsa_priv_size(key);
 }
@@ -538,13 +470,13 @@ size_t ccrsa_export_priv_size(const ccrsa_full_ctx_t key) {
 /*!
  @function   ccrsa_export_priv
  @abstract   Export a full key in PKCS#1 format.
- 
+
  @param      key        Full key
  @param      out_len    Allocated size
  @param      out        Output buffer
  */
 
-CC_CONST CC_INLINE CC_NONNULL_TU((1)) CC_NONNULL((3))
+CC_CONST CC_INLINE CC_NONNULL((1, 3))
 int ccrsa_export_priv(const ccrsa_full_ctx_t key, size_t out_len, uint8_t *out) {
     return (ccder_encode_rsa_priv(key, out, out+out_len) != out);
 }
@@ -552,10 +484,10 @@ int ccrsa_export_priv(const ccrsa_full_ctx_t key, size_t out_len, uint8_t *out) 
 /*!
  @function   ccrsa_import_priv_n
  @abstract   Calculate size of full key exported in PKCS#1 format.
- 
+
  @param      inlen        Length of PKCS#1 package data
  @param      der           pointer to PKCS#1 package data
- 
+
  @result the "n" of the RSA key that would result from the import.  This can be used
  to declare the key itself.
  */
@@ -568,24 +500,24 @@ cc_size ccrsa_import_priv_n(size_t inlen, const uint8_t *der) {
 /*!
  @function   ccrsa_import_priv
  @abstract   Import a full RSA key from a package in PKCS#1 format.
- 
+
  @param      key          Full key (n must be set)
  @param      inlen        Length of PKCS#1 package data
  @param      der           pointer to PKCS#1 package data
- 
+
  @result     Key is initialized using the data in the PKCS#1 message.
  */
 
-CC_CONST CC_INLINE CC_NONNULL_TU((1)) CC_NONNULL((3))
+CC_CONST CC_INLINE CC_NONNULL((1, 3))
 int ccrsa_import_priv(ccrsa_full_ctx_t key, size_t inlen, const uint8_t *der) {
     return (ccder_decode_rsa_priv(key, der, der+inlen) == NULL);
 }
 
 
-CC_NONNULL_TU((1)) CC_NONNULL2
+CC_NONNULL((1, 2))
 int ccrsa_get_pubkey_components(const ccrsa_pub_ctx_t pubkey, uint8_t *modulus, size_t *modulusLength, uint8_t *exponent, size_t *exponentLength);
 
-CC_NONNULL_TU((1)) CC_NONNULL2
+CC_NONNULL((1, 2))
 int ccrsa_get_fullkey_components(const ccrsa_full_ctx_t key, uint8_t *modulus, size_t *modulusLength, uint8_t *exponent, size_t *exponentLength,
                                  uint8_t *p, size_t *pLength, uint8_t *q, size_t *qLength);
 

--- a/include/corecrypto/ccsha1.h
+++ b/include/corecrypto/ccsha1.h
@@ -21,23 +21,11 @@
 /* sha1 selector */
 const struct ccdigest_info *ccsha1_di(void);
 
-extern const uint32_t ccsha1_initial_state[5];
-
-/* shared between several implementations */
-void ccsha1_final(const struct ccdigest_info *di, ccdigest_ctx_t,
-                  unsigned char *digest);
-
-
 /* Implementations */
 extern const struct ccdigest_info ccsha1_ltc_di;
 extern const struct ccdigest_info ccsha1_eay_di;
 
 #if  CCSHA1_VNG_INTEL
-//extern const struct ccdigest_info ccsha1_vng_intel_di;
-#if defined(__x86_64__)
-extern const struct ccdigest_info ccsha1_vng_intel_AVX2_di;
-extern const struct ccdigest_info ccsha1_vng_intel_AVX1_di;
-#endif
 extern const struct ccdigest_info ccsha1_vng_intel_SupplementalSSE3_di;
 #endif
 

--- a/include/corecrypto/ccsha2.h
+++ b/include/corecrypto/ccsha2.h
@@ -38,33 +38,14 @@ const struct ccdigest_info *ccsha512_di(void);
 #define	CCSHA256_OUTPUT_SIZE 32
 #define	CCSHA256_STATE_SIZE  32
 extern const struct ccdigest_info ccsha256_ltc_di;
-extern const struct ccdigest_info ccsha256_v6m_di;
 #if  CCSHA2_VNG_INTEL
-#if defined __x86_64__
-extern const struct ccdigest_info ccsha224_vng_intel_AVX2_di;
-extern const struct ccdigest_info ccsha224_vng_intel_AVX1_di;
-extern const struct ccdigest_info ccsha256_vng_intel_AVX2_di;
-extern const struct ccdigest_info ccsha256_vng_intel_AVX1_di;
-extern const struct ccdigest_info ccsha384_vng_intel_AVX2_di;
-extern const struct ccdigest_info ccsha384_vng_intel_AVX1_di;
-extern const struct ccdigest_info ccsha384_vng_intel_SupplementalSSE3_di;
-extern const struct ccdigest_info ccsha512_vng_intel_AVX2_di;
-extern const struct ccdigest_info ccsha512_vng_intel_AVX1_di;
-extern const struct ccdigest_info ccsha512_vng_intel_SupplementalSSE3_di;
-#endif
 extern const struct ccdigest_info ccsha224_vng_intel_SupplementalSSE3_di;
 extern const struct ccdigest_info ccsha256_vng_intel_SupplementalSSE3_di;
 #endif
 #if  CCSHA2_VNG_ARMV7NEON
 extern const struct ccdigest_info ccsha224_vng_armv7neon_di;
 extern const struct ccdigest_info ccsha256_vng_armv7neon_di;
-extern const struct ccdigest_info ccsha384_vng_arm64_di;
-extern const struct ccdigest_info ccsha384_vng_armv7neon_di;
-extern const struct ccdigest_info ccsha512_vng_arm64_di;
-extern const struct ccdigest_info ccsha512_vng_armv7neon_di;
 #endif
-extern const uint32_t ccsha256_K[64];
-extern const uint64_t ccsha512_K[80];
 
 /* SHA224 */
 #define	CCSHA224_OUTPUT_SIZE 28

--- a/include/corecrypto/cczp.h
+++ b/include/corecrypto/cczp.h
@@ -14,57 +14,43 @@
 #include <corecrypto/ccn.h>
 #include <corecrypto/ccrng.h>
 
-/* 
- Don't use cczp_hd struct directly, except in static tables such as eliptic curve parameter definitions.
- 
- Declare cczp objects using cczp_decl_n(). It allocates cc_unit arrays of the length returned by either cczp_nof_n() or cczp_short_nof_n().
+/*
+ Don't use cczp_hd struct directly, except in static tables such as eliptic curve parameter
+ definitions.
+
+ Declare cczp objects using cczp_decl_n(). It allocates cc_unit arrays of the length returned by
+ either cczp_nof_n() or cczp_short_nof_n().
 */
 
 struct cczp;
-#if CORECRYPTO_USE_TRANSPARENT_UNION
 
-typedef union {
-    cc_unit *u;
-    struct cczp *zp;
-    //cczp_const_t czp; //for automatic type cast
-    //struct cczp_prime *prime;
-} cczp_t __attribute__((transparent_union));
+typedef struct cczp *cczp_t;
+typedef const struct cczp *cczp_const_t;
 
-typedef union {
-    const cc_unit *u;
-    const struct cczp *zp;
-    //const struct cczp_prime *prime;
-    cczp_t _nczp;
-} cczp_const_t __attribute__((transparent_union));
-
-#else
-    typedef struct cczp* cczp_t;
-    typedef const struct cczp* cczp_const_t;
-#endif
-typedef void (*ccmod_func_t)(cczp_const_t zp, cc_unit *r, const cc_unit *s, cc_ws_t ws);
+typedef void (*ccmod_func_t)(cc_ws_t ws, cczp_const_t zp, cc_unit *r, const cc_unit *s);
 
 // keep cczp_hd and cczp structures consistent
 // cczp_hd is typecasted to cczp to read EC curve params
 // options field is to specify Montgomery arithmetic, bit field, etc
-// make sure n is the first element see ccrsa_ctx_n macro 
+// make sure n is the first element see ccrsa_ctx_n macro
 #define __CCZP_HEADER_ELEMENTS_DEFINITIONS(pre) \
-cc_size pre ## n;\
-cc_unit pre ## options;\
-ccmod_func_t pre ## mod_prime;
+    cc_size pre##n;                             \
+    cc_unit pre##options;                       \
+    ccmod_func_t pre##mod_prime;
 
-#define __CCZP_ELEMENTS_DEFINITIONS(pre) \
-__CCZP_HEADER_ELEMENTS_DEFINITIONS(pre) \
-cc_unit pre ## ccn[];
+#define __CCZP_ELEMENTS_DEFINITIONS(pre)    \
+    __CCZP_HEADER_ELEMENTS_DEFINITIONS(pre) \
+    cc_unit pre##ccn[];
 
-//cczp_hd must be defined separetly without variable length array ccn[], because it is used in sructures such as ccdh_gp_decl_n
-struct cczp_hd{
+// cczp_hd must be defined separetly without variable length array ccn[], because it is used in
+// sructures such as ccdh_gp_decl_n
+struct cczp_hd {
     __CCZP_HEADER_ELEMENTS_DEFINITIONS()
-}  CC_ALIGNED(CCN_UNIT_SIZE);
+} CC_ALIGNED(CCN_UNIT_SIZE);
 
 struct cczp {
     __CCZP_ELEMENTS_DEFINITIONS()
 } CC_ALIGNED(CCN_UNIT_SIZE);
-
 
 /* Return the size of an cczp where each ccn is _size_ bytes. */
 #define cczp_size(_size_) (sizeof(struct cczp) + ccn_sizeof_n(1) + 2 * (_size_))
@@ -79,113 +65,71 @@ struct cczp {
    with cczp_add, cczp_sub, cczp_div2, cczp_mod_inv. */
 #define cczp_short_nof_n(_n_) (ccn_nof_size(sizeof(struct cczp)) + (_n_))
 
-#define cczp_decl_n(_n_, _name_)  cc_ctx_decl(struct cczp, ccn_sizeof_n(cczp_nof_n(_n_)), _name_)
-#define cczp_short_decl_n(_n_, _name_) cc_ctx_decl(struct cczp_short, ccn_sizeof_n(cczp_short_nof_n(_n_)), _name_)
+#define cczp_decl_n(_n_, _name_) cc_ctx_decl(struct cczp, ccn_sizeof_n(cczp_nof_n(_n_)), _name_)
+#define cczp_short_decl_n(_n_, _name_) \
+    cc_ctx_decl(struct cczp_short, ccn_sizeof_n(cczp_short_nof_n(_n_)), _name_)
 
-#define cczp_clear_n(_n_, _name_)  cc_clear(ccn_sizeof_n(cczp_nof_n(_n_)), _name_)
-#define cczp_short_clear_n(_n_, _name_)  cc_clear(ccn_sizeof_n(cczp_short_nof_n(_n_)), _name_)
+#define cczp_clear_n(_n_, _name_) cc_clear(ccn_sizeof_n(cczp_nof_n(_n_)), _name_)
+#define cczp_short_clear_n(_n_, _name_) cc_clear(ccn_sizeof_n(cczp_short_nof_n(_n_)), _name_)
 
-#if CORECRYPTO_USE_TRANSPARENT_UNION 
-  #define CCZP_N(ZP) (((cczp_t)(ZP)).zp->n)
-  #define CCZP_MOD(ZP) (((cczp_t)(ZP)).zp->mod_prime)
-  #define CCZP_PRIME(ZP) (((cczp_t)(ZP)).zp->ccn)
-  #define CCZP_RECIP(ZP) (((cczp_t)(ZP)).zp->ccn + cczp_n(ZP))
-  #define CCZP_OPS(ZP) ((ZP).zp->options)
-  #define CCZP_MOD_PRIME(ZP) CCZP_MOD(ZP)
-
-CC_CONST CC_NONNULL_TU((1))
-static inline cc_size cczp_n(cczp_const_t zp) {
-    return zp.zp->n;
-}
-
-CC_CONST CC_NONNULL_TU((1))
-static inline cc_unit cczp_options(cczp_const_t zp) {
-    return zp.zp->options;
-}
-
-CC_CONST CC_NONNULL_TU((1))
-static inline ccmod_func_t cczp_mod_prime(cczp_const_t zp) {
-    return zp.zp->mod_prime;
-}
-
-CC_CONST CC_NONNULL_TU((1))
-static inline const cc_unit *cczp_prime(cczp_const_t zp) {
-    return zp.zp->ccn;
-}
-
-/* Return a pointer to the Reciprocal or Montgomery constant of zp, which is
- allocated cczp_n(zp) + 1 units long. */
-CC_CONST CC_NONNULL_TU((1))
-
-static inline const cc_unit *cczp_recip(cczp_const_t zp) {
-    return zp.zp->ccn + zp.zp->n;
-}
-
-#else
-  #define CCZP_N(ZP)     ((ZP)->n)
-  #define CCZP_MOD(ZP)   ((ZP)->mod_prime)
-  #define CCZP_MOD_PRIME(ZP) CCZP_MOD(ZP)
-  #define CCZP_PRIME(ZP) ((ZP)->ccn)
-  #define CCZP_RECIP(ZP) ((ZP)->ccn + CCZP_N(ZP))
-  #define CCZP_OPS(ZP)   ((ZP)->options)
-CC_CONST CC_NONNULL_TU((1))
-static inline cc_size cczp_n(cczp_const_t zp) {
+#define CCZP_N(ZP) ((ZP)->n)
+#define CCZP_MOD(ZP) ((ZP)->mod_prime)
+#define CCZP_MOD_PRIME(ZP) CCZP_MOD(ZP)
+#define CCZP_PRIME(ZP) ((ZP)->ccn)
+#define CCZP_RECIP(ZP) ((ZP)->ccn + CCZP_N(ZP))
+#define CCZP_OPS(ZP) ((ZP)->options)
+CC_CONST CC_NONNULL((1)) static inline cc_size cczp_n(cczp_const_t zp)
+{
     return zp->n;
 }
 
-CC_CONST CC_NONNULL_TU((1))
-static inline cc_unit cczp_options(cczp_const_t zp) {
+CC_CONST CC_NONNULL((1)) static inline cc_unit cczp_options(cczp_const_t zp)
+{
     return zp->options;
 }
 
-CC_CONST CC_NONNULL_TU((1))
-static inline ccmod_func_t cczp_mod_prime(cczp_const_t zp) {
+CC_CONST CC_NONNULL((1)) static inline ccmod_func_t cczp_mod_prime(cczp_const_t zp)
+{
     return zp->mod_prime;
 }
 
-CC_CONST CC_NONNULL_TU((1))
-static inline const cc_unit *cczp_prime(cczp_const_t zp) {
+CC_CONST CC_NONNULL((1)) static inline const cc_unit *cczp_prime(cczp_const_t zp)
+{
     return zp->ccn;
 }
 
 /* Return a pointer to the Reciprocal or Montgomery constant of zp, which is
  allocated cczp_n(zp) + 1 units long. */
-CC_CONST CC_NONNULL_TU((1))
+CC_CONST CC_NONNULL((1))
 
-static inline const cc_unit *cczp_recip(cczp_const_t zp) {
+    static inline const cc_unit *cczp_recip(cczp_const_t zp)
+{
     return zp->ccn + zp->n;
 }
 
-#endif
-
-
-CC_CONST CC_NONNULL_TU((1))
-CC_INLINE size_t cczp_bitlen(cczp_const_t zp) {
+CC_CONST CC_NONNULL((1)) CC_INLINE size_t cczp_bitlen(cczp_const_t zp)
+{
     return ccn_bitlen(cczp_n(zp), cczp_prime(zp));
 }
 
-
 /* Ensure both cczp_mod_prime(zp) and cczp_recip(zp) are valid. cczp_n and
    cczp_prime must have been previously initialized. */
-CC_NONNULL_TU((1))
-void cczp_init(cczp_t zp);
+CC_NONNULL((1))
+int cczp_init(cczp_t zp);
 
 /* Compute r = s2n mod cczp_prime(zp). Will write cczp_n(zp)
  units to r and reads 2 * cczp_n(zp) units units from s2n. If r and s2n are not
  identical they must not overlap.  Before calling this function either
  cczp_init(zp) must have been called or both CCZP_MOD_PRIME((cc_unit *)zp)
  and CCZP_RECIP((cc_unit *)zp) must be initialized some other way. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-void cczp_mod(cczp_const_t zp, cc_unit *r, const cc_unit *s2n, cc_ws_t ws);
+CC_NONNULL((1, 2, 3)) void cczp_mod(cc_ws_t ws, cczp_const_t zp, cc_unit *r, const cc_unit *s2n);
 
 /* Compute r = sn mod cczp_prime(zp), Will write cczp_n(zp)
  units to r and reads sn units units from s. If r and s are not
  identical they must not overlap.  Before calling this function either
  cczp_init(zp) must have been called or both CCZP_MOD_PRIME((cc_unit *)zp)
  and CCZP_RECIP((cc_unit *)zp) must be initialized some other way. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 4))
-
-int cczp_modn(cczp_const_t zp, cc_unit *r, cc_size ns, const cc_unit *s);
+CC_NONNULL((1, 2, 4)) int cczp_modn(cczp_const_t zp, cc_unit *r, cc_size ns, const cc_unit *s);
 
 /* Compute r = x * y mod cczp_prime(zp). Will write cczp_n(zp) units to r
    and reads cczp_n(zp) units units from both x and y. If r and x are not
@@ -193,44 +137,20 @@ int cczp_modn(cczp_const_t zp, cc_unit *r, cc_size ns, const cc_unit *s);
    calling this function either cczp_init(zp) must have been called or both
    CCZP_MOD_PRIME((cc_unit *)zp) and CCZP_RECIP((cc_unit *)zp) must be
    initialized some other way. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
+CC_NONNULL((1, 2, 3, 4))
 void cczp_mul(cczp_const_t zp, cc_unit *t, const cc_unit *x, const cc_unit *y);
-
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4, 5))
-void cczp_mul_ws(cczp_const_t zp, cc_unit *t, const cc_unit *x, const cc_unit *y, cc_ws_t ws);
-
-/* Compute r = x * x mod cczp_prime(zp). Will write cczp_n(zp) units to r
-   and reads cczp_n(zp) units from x. If r and x are not identical they must
-   not overlap. Before calling this function either cczp_init(zp) must have
-   been called or both CCZP_MOD_PRIME((cc_unit *)zp) and
-   CCZP_RECIP((cc_unit *)zp) must be initialized some other way. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-void cczp_sqr(cczp_const_t zp, cc_unit *r, const cc_unit *x);
-
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
-void cczp_sqr_ws(cczp_const_t zp, cc_unit *r, const cc_unit *x, cc_ws_t ws);
-
-/* Compute r = x^(1/2) mod cczp_prime(zp). Will write cczp_n(zp) units to r
- and reads cczp_n(zp) units from x. If r and x are not identical they must
- not overlap. Before calling this function either cczp_init(zp) must have
- been called or both CCZP_MOD_PRIME((cc_unit *)zp) and
- CCZP_RECIP((cc_unit *)zp) must be initialized some other way. 
- Only support prime = 3 mod 4 */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-int cczp_sqrt(cczp_const_t zp, cc_unit *r, const cc_unit *x);
 
 /* Compute r = m ^ e mod cczp_prime(zp), using Montgomery ladder.
    - writes cczp_n(zp) units to r
    - reads  cczp_n(zp) units units from m and e
-   - if r and m are not identical they must not overlap. 
+   - if r and m are not identical they must not overlap.
    - r and e must not overlap nor be identical.
    - before calling this function either cczp_init(zp) must have been called
    or both CCZP_MOD_PRIME((cc_unit *)zp) and CCZP_RECIP((cc_unit *)zp) must
    be initialized some other way.
  */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
-void cczp_power(cczp_const_t zp, cc_unit *r, const cc_unit *m,
-                const cc_unit *e);
+CC_NONNULL((1, 2, 3, 4))
+int cczp_power(cczp_const_t zp, cc_unit *r, const cc_unit *m, const cc_unit *e);
 
 /* Compute r = m ^ e mod cczp_prime(zp), using Square Square Multiply Always.
  - writes cczp_n(zp) units to r
@@ -239,101 +159,55 @@ void cczp_power(cczp_const_t zp, cc_unit *r, const cc_unit *m,
  - r and e must not overlap nor be identical.
  - before calling this function either cczp_init(zp) must have been called
  or both CCZP_MOD_PRIME((cc_unit *)zp) and CCZP_RECIP((cc_unit *)zp) must
- be initialized some other way. 
- 
+ be initialized some other way.
+
  Important: This function is intented to be constant time but is more likely
     to leak information due to memory cache. Only used with randomized input
  */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
-int cczp_power_ssma(cczp_const_t zp, cc_unit *r, const cc_unit *m,
-                const cc_unit *e);
-
-int cczp_power_ssma_ws(cc_ws_t ws, cczp_const_t zp, cc_unit *r, const cc_unit *s, const cc_unit *e);
-
-/* Compute r = m ^ e mod cczp_prime(zp). Will write cczp_n(zp) units to r and
- reads cczp_n(zp) units units from m.  Reads ebitlen bits from e.
- m must be <= to cczp_prime(zp).  If r and m are not identical they must not
- overlap. r and e must not overlap nor be identical.
- Before calling this function either cczp_init(zp) must have been called
- or both CCZP_MOD_PRIME((cc_unit *)zp) and CCZP_RECIP((cc_unit *)zp) must
- be initialized some other way. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 5))
-void cczp_powern(cczp_const_t zp, cc_unit *r, const cc_unit *s,
-                 size_t ebitlen, const cc_unit *e);
-
-/* Compute r = x + y mod cczp_prime(zp). Will write cczp_n(zp) units to r and
-   reads cczp_n(zp) units units from x and y. If r and x are not identical
-   they must not overlap. Only cczp_n(zp) and cczp_prime(zp) need to be valid.
-   Can be used with cczp_short_nof_n sized cc_unit array zp. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
-void cczp_add(cczp_const_t zp, cc_unit *r, const cc_unit *x,
-              const cc_unit *y);
-
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4, 5))
-void cczp_add_ws(cczp_const_t zp, cc_unit *r, const cc_unit *x,
-                 const cc_unit *y, cc_ws_t ws);
-
-/* Compute r = x - y mod cczp_prime(zp). Will write cczp_n(zp) units to r and
-   reads cczp_n(zp) units units from x and y. If r and x are not identical
-   they must not overlap. Only cczp_n(zp) and cczp_prime(zp) need to be valid.
-   Can be used with cczp_short_nof_n sized cc_unit array zp. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
-void cczp_sub(cczp_const_t zp, cc_unit *r, const cc_unit *x, const cc_unit *y);
-
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4, 5))
-void cczp_sub_ws(cczp_const_t zp, cc_unit *r, const cc_unit *x,
-                 const cc_unit *y, cc_ws_t ws);
-
-/* Compute r = x / 2 mod cczp_prime(zp). Will write cczp_n(zp) units to r and
-   reads cczp_n(zp) units units from x. If r and x are not identical
-   they must not overlap. Only cczp_n(zp) and cczp_prime(zp) need to be valid.
-   Can be used with cczp_short_nof_n sized cc_unit array zp. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-void cczp_div2(cczp_const_t zp, cc_unit *r, const cc_unit *x);
-
-/* Compute q = a_2n / cczp_prime(zd) (mod cczp_prime(zd)) . Will write cczp_n(zd)
-   units to q and r. Will read 2 * cczp_n(zd) units units from a. If r and a
-   are not identical they must not overlap. Before calling this function
-   either cczp_init(zp) must have been called or both
-   CCZP_MOD_PRIME((cc_unit *)zp) and CCZP_RECIP((cc_unit *)zp) must be
-   initialized some other way. */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3, 4))
-void cczp_div(cczp_const_t zd, cc_unit *q, cc_unit *r, const cc_unit *a_2n);
-
+CC_NONNULL((1, 2, 3, 4))
+int cczp_power_ssma(cczp_const_t zp, cc_unit *r, const cc_unit *m, const cc_unit *e);
 
 /*!
  @brief cczp_inv(zp, r, x) computes r = x^-1 (mod p) , where p=cczp_prime(zp).
- @discussion It is a general function and works for any p. It validates the inputs. r and x can overlap. It writes n =cczp_n(zp) units to r, and read n units units from x and p. The output r is overwriten only if the inverse is correctly computed. This function is not constant time in absolute sense, but it does not have data dependent 'if' statements in the code.
- @param zp  The input zp. cczp_n(zp) and cczp_prime(zp) need to be valid. cczp_init(zp) need not to be called before invoking cczp_inv().
+ @discussion It is a general function and works for any p. It validates the inputs. r and x can
+ overlap. It writes n =cczp_n(zp) units to r, and read n units units from x and p. The output r is
+ overwriten only if the inverse is correctly computed. This function is not constant time in
+ absolute sense, but it does not have data dependent 'if' statements in the code.
+ @param zp  The input zp. cczp_n(zp) and cczp_prime(zp) need to be valid. cczp_init(zp) need not to
+ be called before invoking cczp_inv().
  @param x input big integer
  @param r output big integer
  @return  0 if inverse exists and correctly computed.
  */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-
+CC_NONNULL((1, 2, 3))
 int cczp_inv(cczp_const_t zp, cc_unit *r, const cc_unit *x);
 
 /*!
  @brief cczp_inv_odd(zp, r, x) computes r = x^-1 (mod p) , where p=cczp_prime(zp) is an odd number.
  @discussion  r and x can overlap.
- @param zp  The input zp. cczp_n(zp) and cczp_prime(zp) need to be valid. cczp_init(zp) need not to be called before invoking.
+ @param zp  The input zp. cczp_n(zp) and cczp_prime(zp) need to be valid. cczp_init(zp) need not to
+ be called before invoking.
  @param x input big integer
  @param r output big integer
  @return  0 if successful
  */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
-int cczp_inv_odd(cczp_const_t zp, cc_unit *r, const cc_unit *x);
+CC_NONNULL((1, 2, 3)) int cczp_inv_odd(cczp_const_t zp, cc_unit *r, const cc_unit *x);
 
 /*!
- @brief cczp_inv_field(zp, r, x) computes r = x^-1 (mod p) , where p=cczp_prime(zp) is a prime number number.
- @discussion r and x must NOT overlap. The excution time of the function is independent to the value of the input x. It works only if p is a field. That is, when p is a prime. It supports Montgomery and non-Montgomery form of zp. It leaks the value of the prime and should only be used be used for public (not secret) primes (ex. Elliptic Curves)
+ @brief cczp_inv_field(zp, r, x) computes r = x^-1 (mod p) , where p=cczp_prime(zp) is a prime
+ number number.
+ @discussion r and x must NOT overlap. The excution time of the function is independent to the value
+ of the input x. It works only if p is a field. That is, when p is a prime. It supports Montgomery
+ and non-Montgomery form of zp. It leaks the value of the prime and should only be used be used for
+ public (not secret) primes (ex. Elliptic Curves)
 
- @param zp  The input zp. cczp_n(zp) and cczp_prime(zp) need to be valid. cczp_init(zp) need not to be called before invoking cczp_inv_field().
+ @param zp  The input zp. cczp_n(zp) and cczp_prime(zp) need to be valid. cczp_init(zp) need not to
+ be called before invoking cczp_inv_field().
  @param x input big unteger
  @param r output big integer
  @return  0 if inverse exists and correctly computed.
  */
-CC_NONNULL_TU((1)) CC_NONNULL((2, 3))
+CC_NONNULL((1, 2, 3))
 int cczp_inv_field(cczp_const_t zp, cc_unit *r, const cc_unit *x);
 
 #endif /* _CORECRYPTO_CCZP_H_ */

--- a/include/corecrypto/fipspost_trace.h
+++ b/include/corecrypto/fipspost_trace.h
@@ -1,0 +1,45 @@
+/*
+ *  fipspost_trace.h
+ *  corecrypto
+ *
+ *  Created on 01/25/2017
+ *
+ *  Copyright (c) 2017 Apple Inc. All rights reserved.
+ *
+ */
+
+#ifndef _CORECRYPTO_FIPSPOST_TRACE_H_
+#define _CORECRYPTO_FIPSPOST_TRACE_H_
+
+#if CC_FIPSPOST_TRACE
+
+/*
+ * Use this string to separate out tests.
+ */
+#define FIPSPOST_TRACE_TEST_STR    "?"
+
+int fipspost_trace_is_active(void);
+void fipspost_trace_call(const char *fname);
+
+/* Only trace when VERBOSE is set to avoid impacting normal boots. */
+#define FIPSPOST_TRACE_EVENT do {                                       \
+    if (fipspost_trace_is_active()) {                                   \
+        fipspost_trace_call(__FUNCTION__);                              \
+    }                                                                   \
+} while (0);
+
+#define FIPSPOST_TRACE_MESSAGE(MSG) do {                                \
+    if (fipspost_trace_is_active()) {                                   \
+        fipspost_trace_call(MSG);                                       \
+    }                                                                   \
+} while (0);
+
+#else
+
+/* Not building a CC_FIPSPOST_TRACE-enabled, no TRACE operations. */
+#define FIPSPOST_TRACE_EVENT
+#define FIPSPOST_TRACE_MESSAGE(X)
+
+#endif
+
+#endif

--- a/src/algorithms/cckprng.c
+++ b/src/algorithms/cckprng.c
@@ -2,7 +2,7 @@
 //  Botan  http://botan.randombit.net
 //  License :  https://github.com/randombit/botan/blob/master/doc/license.txt
 
-#include <corecrypto/cckprng.h>
+#include "cckprng.h"
 
 int cckprng_init(cckprng_ctx_t ctx, size_t nbytes, const void *seed) {
 	// Nothing to do here, rdrand cannot be seeded.

--- a/src/algorithms/cckprng.c
+++ b/src/algorithms/cckprng.c
@@ -47,17 +47,21 @@ int cckprng_generate(cckprng_ctx_t ctx, size_t nbytes, void *out) {
 	uint8_t *buffer = (uint8_t *)out;
 
 	for (size_t i = 0; i < nbytes; i++) {
-		int mod4 = i % 4;
-		if (mod4 == 0) {
+		int mod8 = i % 8;
+		if (mod8 == 0) {
 			int error = rdrand(&random);
 			if (error != CCKPRNG_OK) return error;
 		}
 
 		uint8_t byte;
-		if (mod4 == 0) byte = random & 0xFF;
-		else if (mod4 == 1) byte = (random >> 8) & 0xFF;
-		else if (mod4 == 2) byte = (random >> 16) & 0xFF;
-		else if (mod4 == 3) byte = (random >> 24) & 0xFF;
+		if (mod8 == 0) byte = random & 0xFF;
+		else if (mod8 == 1) byte = (random >> 8) & 0xFF;
+		else if (mod8 == 2) byte = (random >> 16) & 0xFF;
+		else if (mod8 == 3) byte = (random >> 24) & 0xFF;
+		else if (mod8 == 4) byte = (random >> 32) & 0xFF;
+		else if (mod8 == 5) byte = (random >> 40) & 0xFF;
+		else if (mod8 == 6) byte = (random >> 48) & 0xFF;
+		else if (mod8 == 7) byte = (random >> 56) & 0xFF;
 		else return CCKPRNG_ABORT;
 
 		buffer[i] = byte;

--- a/src/algorithms/cckprng.h
+++ b/src/algorithms/cckprng.h
@@ -1,0 +1,23 @@
+//
+//  cckprng.h
+//  corecrypto_kernel
+//
+//  Created by William Kent on 10/14/19.
+//  Copyright © 2019 William Kent. All rights reserved.
+//
+
+#ifndef __pdcrypto__cckprng__
+#define __pdcrypto__cckprng__
+
+#include <corecrypto/cckprng.h>
+
+__BEGIN_DECLS
+
+extern int cckprng_init(cckprng_ctx_t ctx, size_t nbytes, const void *seed);
+extern int cckprng_reseed(cckprng_ctx_t ctx, size_t nbytes, const void *seed);
+extern int cckprng_addentropy(cckprng_ctx_t ctx, size_t nbytes, const void *seed);
+extern int cckprng_generate(cckprng_ctx_t ctx, size_t nbytes, void *out);
+
+__END_DECLS
+
+#endif /* __pdcrypto__cckprng__ */

--- a/src/kext/Info.plist
+++ b/src/kext/Info.plist
@@ -29,5 +29,7 @@
 		<key>com.apple.kpi.private</key>
 		<string>8.0.0b1</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
 </dict>
 </plist>

--- a/src/kext/Info.plist
+++ b/src/kext/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppleKernelExternalComponent</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -24,10 +26,18 @@
 	<string>Copyright © 2017 PureDarwin Project. All rights reserved.</string>
 	<key>OSBundleLibraries</key>
 	<dict>
+		<key>com.apple.kpi.bsd</key>
+		<string>12.0</string>
+		<key>com.apple.kpi.iokit</key>
+		<string>8.0</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>8.0.0d0</string>
+		<string>11.2</string>
+		<key>com.apple.kpi.mach</key>
+		<string>11.2</string>
 		<key>com.apple.kpi.private</key>
-		<string>8.0.0b1</string>
+		<string>11.2</string>
+		<key>com.apple.kpi.unsupported</key>
+		<string>11.2</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Root</string>

--- a/src/kext/cc_kext_main.c
+++ b/src/kext/cc_kext_main.c
@@ -1,6 +1,8 @@
 #include <sys/systm.h>
 #include <mach/mach_types.h>
 #include "register_crypto.h"
+#include "prng_random.h"
+#include "../algorithms/cckprng.h"
 
 extern struct crypto_functions pdcrypto_internal_functions;
 
@@ -9,10 +11,16 @@ kern_return_t cc_kext_start(kmod_info_t * ki, void *d)
 	int ret = register_crypto_functions(&pdcrypto_internal_functions);
 	if (ret == -1) {
 		printf("warning: corecrypto could not be registered. Did another crypto handler beat us to it?\n");
-	} else {
-		printf("corecrypto loaded\n");
 	}
 
+	struct prng_fns fns;
+	fns.init = cckprng_init;
+	fns.reseed = cckprng_reseed;
+	fns.addentropy = cckprng_addentropy;
+	fns.generate = cckprng_generate;
+	register_and_init_prng(&fns);
+
+	printf("corecrypto loaded\n");
     return KERN_SUCCESS;
 }
 

--- a/src/kext/cc_kext_main.c
+++ b/src/kext/cc_kext_main.c
@@ -6,21 +6,23 @@
 
 extern struct crypto_functions pdcrypto_internal_functions;
 
+static const struct prng_fns cc_kprng_fns = {
+	.init = cckprng_init,
+	.reseed = cckprng_reseed,
+	.addentropy = cckprng_addentropy,
+	.generate = cckprng_generate
+};
+
 kern_return_t cc_kext_start(kmod_info_t * ki, void *d)
 {
 	int ret = register_crypto_functions(&pdcrypto_internal_functions);
 	if (ret == -1) {
 		printf("warning: corecrypto could not be registered. Did another crypto handler beat us to it?\n");
+	} else {
+		register_and_init_prng(&cc_kprng_fns);
+		printf("corecrypto loaded\n");
 	}
 
-	struct prng_fns fns;
-	fns.init = cckprng_init;
-	fns.reseed = cckprng_reseed;
-	fns.addentropy = cckprng_addentropy;
-	fns.generate = cckprng_generate;
-	register_and_init_prng(&fns);
-
-	printf("corecrypto loaded\n");
     return KERN_SUCCESS;
 }
 

--- a/src/kext/cckprng.c
+++ b/src/kext/cckprng.c
@@ -1,0 +1,67 @@
+//  adapted from botan/src/lib/rng/rdrnd_rng/rdrand_rng.cpp
+//  Botan  http://botan.randombit.net
+//  License :  https://github.com/randombit/botan/blob/master/doc/license.txt
+
+#include <corecrypto/cckprng.h>
+
+int cckprng_init(cckprng_ctx_t ctx, size_t nbytes, const void *seed) {
+	// Nothing to do here, rdrand cannot be seeded.
+	return CCKPRNG_OK;
+}
+
+int cckprng_reseed(cckprng_ctx_t ctx, size_t nbytes, const void *seed) {
+	// Nothing to do here, rdrand cannot be seeded.
+	return CCKPRNG_OK;
+}
+
+int cckprng_addentropy(cckprng_ctx_t ctx, size_t nbytes, const void *seed) {
+	// Nothing to do here, rdrand cannot be seeded.
+	return CCKPRNG_OK;
+}
+
+// MARK: -
+
+static int rdrand(uint64_t *value) {
+	if (value == NULL) return CCKPRNG_ABORT;
+
+	// According to Intel, RDRAND is guaranteed to generate a random
+	// number within 10 retries on a working CPU.
+	const size_t retries = 10;
+	for (size_t i = 0; i < retries; i++) {
+		uint64_t output = 0;
+		int cf = 0;
+
+		asm("rdrand %0; adcl $0, %1" : "=r" (output), "=r" (cf) : "0" (output), "1" (cf) : "cc");
+
+		if (cf == 1) {
+			*value = output;
+			return CCKPRNG_OK;
+		}
+	}
+
+	return CCKPRNG_ABORT;
+}
+
+int cckprng_generate(cckprng_ctx_t ctx, size_t nbytes, void *out) {
+	uint64_t random = 0;
+	uint8_t *buffer = (uint8_t *)out;
+
+	for (size_t i = 0; i < nbytes; i++) {
+		int mod4 = i % 4;
+		if (mod4 == 0) {
+			int error = rdrand(&random);
+			if (error != CCKPRNG_OK) return error;
+		}
+
+		uint8_t byte;
+		if (mod4 == 0) byte = random & 0xFF;
+		else if (mod4 == 1) byte = (random >> 8) & 0xFF;
+		else if (mod4 == 2) byte = (random >> 16) & 0xFF;
+		else if (mod4 == 3) byte = (random >> 24) & 0xFF;
+		else return CCKPRNG_ABORT;
+
+		buffer[i] = byte;
+	}
+
+	return CCKPRNG_OK;
+}

--- a/src/kext/prng_random.h
+++ b/src/kext/prng_random.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+
+#ifndef _PRNG_RANDOM_H_
+#define _PRNG_RANDOM_H_
+
+__BEGIN_DECLS
+
+#include <corecrypto/cckprng.h>
+
+/* kernel prng */
+typedef const struct prng_fns {
+	int (*init)(cckprng_ctx_t ctx, size_t nbytes, const void * seed);
+	int (*reseed)(cckprng_ctx_t ctx, size_t nbytes, const void * seed);
+	int (*addentropy)(cckprng_ctx_t ctx, size_t nbytes, const void * entropy);
+	int (*generate)(cckprng_ctx_t ctx, size_t nbytes, void * out);
+} * prng_fns_t;
+
+void register_and_init_prng(prng_fns_t fns);
+
+__END_DECLS
+
+#endif /* _PRNG_RANDOM_H_ */


### PR DESCRIPTION
xnu-4903.221.2 requires that this API is registered with the kernel by corecrypto upon load, or else the kernel will attempt to jump through an uninitialized pointer later, and crash messily.